### PR TITLE
Fixing wrong log

### DIFF
--- a/PolarAlignment/Instructions/PolarAlignment.cs
+++ b/PolarAlignment/Instructions/PolarAlignment.cs
@@ -764,7 +764,7 @@ namespace NINA.Plugins.PolarAlignment.Instructions {
 
                 var adjustedRate = rate;
                 if (foundRate.Item2 < rate) {
-                    Logger.Warning($"Provided MoveRate of {rate} is not supported. Using {adjustedRate} instead");
+                    Logger.Warning($"Provided MoveRate of {rate} is not supported. Using {foundRate.Item2} instead");
                     //The closest rate is below the specified move rate as no move rate is found for the value
                     adjustedRate = foundRate.Item2;
                 }


### PR DESCRIPTION
At this point of the code adjustedRate is equal to rate. If we are going to trace the new adjustedRate we need to use foundRate.Item2  

Another option is to move the log after assigning adjustedRate the new rate value (foundRate.Item2)