### PR TITLE
Fix alignment tolerance field to accept decimal values

### DIFF
--- a/PolarAlignment/Changelog.md
+++ b/PolarAlignment/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.2.6.4
+- Alignment Tolerance now accepts decimal values (e.g. `0.5` = 30 arcseconds). The instruction template bound the field with `UpdateSourceTrigger=PropertyChanged`, which re-parsed the text on every keystroke and silently swallowed the decimal separator — only integers could effectively be typed. The binding now commits on focus loss with `StringFormat 0.##`. Same fix applied to the Options "Default Alignment Tolerance" field; tooltips and the pre-flight validation message updated accordingly.
+
 ## Version 2.2.6.3
 - Improved correction-loop performance by avoiding star detection until a reference star is manually selected, then projecting that locked star between frames and re-detecting only after 120 seconds, a field shift over 0.5 degrees, or an outside-image projection.
 

--- a/PolarAlignment/Instructions/PolarAlignment.cs
+++ b/PolarAlignment/Instructions/PolarAlignment.cs
@@ -951,7 +951,7 @@ namespace NINA.Plugins.PolarAlignment.Instructions {
             }
 
             if (PolarAlignmentPlugin.ActiveAlignmentSystemVM != null && PolarAlignmentPlugin.ActiveAlignmentSystemVM?.DoAutomatedAdjustments == true && AlignmentTolerance == 0) {
-                i.Add("Automated adjustments are enabled, but polar alignment tolerance is set to zero. Please set an alignment tolerance!");
+                i.Add("Automated adjustments are enabled, but polar alignment tolerance is set to zero. Please set an alignment tolerance greater than zero - decimal values like 0.5 arcmin are supported!");
             }
 
 

--- a/PolarAlignment/NINA.Plugins.PolarAlignment.csproj
+++ b/PolarAlignment/NINA.Plugins.PolarAlignment.csproj
@@ -12,7 +12,7 @@
     <Product>NINA.Plugins</Product>
     <Description>Three Point Polar Alignment almost anywhere in the sky</Description>
     <Copyright>Copyright ©  2021-2025</Copyright>
-    <Version>2.2.6.3</Version>
+    <Version>2.2.6.4</Version>
   </PropertyGroup>
   <ItemGroup>    
     <PackageReference Include="NINA.Plugin" Version="3.1.2.9001" />    

--- a/PolarAlignment/Options.xaml
+++ b/PolarAlignment/Options.xaml
@@ -26,7 +26,7 @@
     <s:String x:Key="MoveTimeoutFactorToolTip">Multiplier applied to the computed automatic RA-move timeout. TPPA calculates the timeout as move distance divided by move rate, then multiplies by this factor.</s:String>
     <s:String x:Key="DefaultAzimuthOffsetToolTip">Default azimuth offset used when TPPA creates start coordinates instead of starting from the current position. In the southern hemisphere TPPA applies this offset relative to 180 degrees.</s:String>
     <s:String x:Key="DefaultAltitudeOffsetToolTip">Default altitude offset added when TPPA creates start coordinates instead of starting from the current position.</s:String>
-    <s:String x:Key="AlignmentToleranceToolTip">Arcminute threshold used for automatic completion when the reported total error falls at or below it. Automated adjustments require this value to be non-zero.</s:String>
+    <s:String x:Key="AlignmentToleranceToolTip">Arcminute threshold used for automatic completion when the reported total error falls at or below it. Decimal values are allowed, e.g. 0.5 for 30 arcseconds. Automated adjustments require this value to be non-zero.</s:String>
     <s:String x:Key="AltitudeErrorColorToolTip">Color used for the altitude-error overlay elements in the live TPPA display.</s:String>
     <s:String x:Key="AzimuthErrorColorToolTip">Color used for the azimuth-error overlay elements in the live TPPA display.</s:String>
     <s:String x:Key="TotalErrorColorToolTip">Color used for the total-error overlay elements in the live TPPA display.</s:String>
@@ -218,7 +218,7 @@
                             Margin="5,5,0,0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
-                            Text="{Binding AlignmentTolerance}"
+                            Text="{Binding AlignmentTolerance, StringFormat={}{0:0.##}}"
                             ToolTip="{StaticResource AlignmentToleranceToolTip}"
                             Unit="arcmin" />
 

--- a/PolarAlignment/Resources/PolarAlignmentInstructionTemplate.xaml
+++ b/PolarAlignment/Resources/PolarAlignmentInstructionTemplate.xaml
@@ -173,14 +173,14 @@
                 <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
                     <TextBlock VerticalAlignment="Center" Text="Alignment Tolerance">
                         <TextBlock.ToolTip>
-                            <TextBlock Text="Setting the Polar Alignment Tolerance to non-zero will specify a tolerance in arcminutes where the polar alignment routine automatically completes when below the threshold" />
+                            <TextBlock Text="Setting the Polar Alignment Tolerance to non-zero will specify a tolerance in arcminutes where the polar alignment routine automatically completes when below the threshold. Decimal values are allowed, e.g. 0.5 for 30 arcseconds" />
                         </TextBlock.ToolTip>
                     </TextBlock>
                     <ninactrl:UnitTextBox
                         MinWidth="40"
                         Margin="5,0,0,0"
                         VerticalAlignment="Center"
-                        Text="{Binding AlignmentTolerance, UpdateSourceTrigger=PropertyChanged}"
+                        Text="{Binding AlignmentTolerance, UpdateSourceTrigger=LostFocus, StringFormat={}{0:0.##}}"
                         Unit="arcmin" />
                 </StackPanel>
             </WrapPanel>


### PR DESCRIPTION
First of the split series from #13 (1 of 4), as discussed there.

## What

The Alignment Tolerance field only accepted whole numbers: the instruction template bound it with `UpdateSourceTrigger=PropertyChanged`, so the text was re-parsed on every keystroke and the trailing decimal separator was silently swallowed — typing `0.5` effectively produced `5`.

- Binding now commits on focus loss with `StringFormat {0:0.##}` (instruction template + Options "Default Alignment Tolerance")
- Tooltips mention that decimals are allowed (e.g. `0.5` = 30 arcseconds)
- Pre-flight validation message updated accordingly

## Scope

UI bindings and strings only — no behavior change for existing integer values, no shared runtime paths touched. `AlignmentTolerance` was already a `double` end to end.

## Testing

- Build + full test suite green (47/47)
- Manual: typed `0.5`, `1.25`, `2` in both fields; values persist and auto-finish triggers at the decimal threshold

Next in the series: auto-finish confirmation (2 consecutive solves below tolerance).
