### PR TITLE
Require 2 consecutive below-tolerance solves before auto-finishing

### DIFF
--- a/NINA.Plugins.PolarAlignment.Test/AutoFinishGateTest.cs
+++ b/NINA.Plugins.PolarAlignment.Test/AutoFinishGateTest.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using NINA.Plugins.PolarAlignment.Instructions;
+
+namespace NINA.Plugins.PolarAlignment.Test {
+
+    public class AutoFinishGateTest {
+
+        [Test]
+        public void SingleBelowToleranceSolve_DoesNotFinish() {
+            var gate = new AutoFinishGate(2);
+
+            gate.Register(belowTolerance: true).Should().BeFalse();
+            gate.Consecutive.Should().Be(1);
+        }
+
+        [Test]
+        public void TwoConsecutiveBelowToleranceSolves_Finish() {
+            var gate = new AutoFinishGate(2);
+
+            gate.Register(belowTolerance: true).Should().BeFalse();
+            gate.Register(belowTolerance: true).Should().BeTrue();
+        }
+
+        [Test]
+        public void AboveToleranceSolve_ResetsPendingConfirmation() {
+            var gate = new AutoFinishGate(2);
+
+            gate.Register(belowTolerance: true).Should().BeFalse();
+            gate.Register(belowTolerance: false).Should().BeFalse();
+            gate.Consecutive.Should().Be(0);
+
+            // A fresh single below-tolerance solve must not finish after the reset.
+            gate.Register(belowTolerance: true).Should().BeFalse();
+            gate.Register(belowTolerance: true).Should().BeTrue();
+        }
+
+        [Test]
+        public void PendingConfirmation_IsReportedForHoldingCorrections() {
+            var gate = new AutoFinishGate(2);
+
+            gate.Consecutive.Should().Be(0, "corrections may run before any below-tolerance solve");
+            gate.Register(belowTolerance: true);
+            gate.Consecutive.Should().BePositive("corrections must hold while a confirmation solve is pending");
+        }
+
+        [Test]
+        public void RequiredConsecutiveOfOne_FinishesImmediately() {
+            var gate = new AutoFinishGate(1);
+
+            gate.Register(belowTolerance: true).Should().BeTrue();
+        }
+    }
+}

--- a/PolarAlignment/Changelog.md
+++ b/PolarAlignment/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.2.6.5
+- Automatic completion now requires 2 consecutive solves below the alignment tolerance before finishing, so a single lucky solve cannot end a non-converged procedure. While a below-tolerance result awaits confirmation, automated corrections hold still so the confirmation solve measures the same state.
+
 ## Version 2.2.6.4
 - Alignment Tolerance now accepts decimal values (e.g. `0.5` = 30 arcseconds). The instruction template bound the field with `UpdateSourceTrigger=PropertyChanged`, which re-parsed the text on every keystroke and silently swallowed the decimal separator — only integers could effectively be typed. The binding now commits on focus loss with `StringFormat 0.##`. Same fix applied to the Options "Default Alignment Tolerance" field; tooltips and the pre-flight validation message updated accordingly.
 

--- a/PolarAlignment/Instructions/AutoFinishGate.cs
+++ b/PolarAlignment/Instructions/AutoFinishGate.cs
@@ -1,0 +1,31 @@
+namespace NINA.Plugins.PolarAlignment.Instructions {
+
+    /// <summary>
+    /// Gates automatic completion of the polar alignment on consecutive confirmations
+    /// below the tolerance, so a single lucky solve cannot end a non-converged procedure.
+    /// </summary>
+    public sealed class AutoFinishGate {
+        private readonly int requiredConsecutive;
+
+        public AutoFinishGate(int requiredConsecutive) {
+            this.requiredConsecutive = requiredConsecutive;
+        }
+
+        /// <summary>
+        /// Number of consecutive below-tolerance confirmations registered so far.
+        /// Non-zero means a confirmation solve is pending and corrections should hold.
+        /// </summary>
+        public int Consecutive { get; private set; }
+
+        public int RequiredConsecutive => requiredConsecutive;
+
+        /// <summary>
+        /// Registers a stable measurement and returns true when enough consecutive
+        /// below-tolerance measurements have been observed to finish the alignment.
+        /// </summary>
+        public bool Register(bool belowTolerance) {
+            Consecutive = belowTolerance ? Consecutive + 1 : 0;
+            return Consecutive >= requiredConsecutive;
+        }
+    }
+}

--- a/PolarAlignment/Instructions/PolarAlignment.cs
+++ b/PolarAlignment/Instructions/PolarAlignment.cs
@@ -578,6 +578,10 @@ namespace NINA.Plugins.PolarAlignment.Instructions {
 
                     await TPAPAVM.UseImageCenterAsReference(localCTS.Token);
 
+                    // A single lucky solve must not end the procedure: require consecutive
+                    // confirmations below tolerance before auto-finishing.
+                    var autoFinishGate = new AutoFinishGate(2);
+
                     var sw = Stopwatch.StartNew();
                     do {
                         await WaitIfPaused(localCTS.Token, progress);
@@ -599,8 +603,8 @@ namespace NINA.Plugins.PolarAlignment.Instructions {
                                 Logger.Info($"Calculated Error: Az: {TPAPAVM.PolarErrorDetermination.CurrentMountAxisAzimuthError}, Alt: {TPAPAVM.PolarErrorDetermination.CurrentMountAxisAltitudeError}, Tot: {TPAPAVM.PolarErrorDetermination.CurrentMountAxisTotalError}");
 
                                 var totalErrorMinutes = Math.Abs(TPAPAVM.PolarErrorDetermination.CurrentMountAxisTotalError.ArcMinutes);
-                                if (totalErrorMinutes <= AlignmentTolerance) {
-                                    Logger.Info($"Total Error is below alignment tolerance ({AlignmentTolerance}'). " +
+                                if (autoFinishGate.Register(totalErrorMinutes <= AlignmentTolerance)) {
+                                    Logger.Info($"Total Error is below alignment tolerance ({AlignmentTolerance}') for {autoFinishGate.Consecutive} consecutive solves. " +
                                         $"Altitude Error: {Math.Round(TPAPAVM.PolarErrorDetermination.CurrentMountAxisAltitudeError.ArcMinutes, 2)}'. " +
                                         $"Azimuth Error: {Math.Round(TPAPAVM.PolarErrorDetermination.CurrentMountAxisAzimuthError.ArcMinutes, 2)}'. " +
                                         $"Total Error: {Math.Round(totalErrorMinutes, 2)}'. " +
@@ -614,6 +618,8 @@ namespace NINA.Plugins.PolarAlignment.Instructions {
                                         $"Automatically finishing polar alignment.",
                                         TimeSpan.FromMinutes(1));
                                     localCTS.Cancel();
+                                } else if (autoFinishGate.Consecutive > 0) {
+                                    Logger.Info($"Total Error {Math.Round(totalErrorMinutes, 2)}' is below alignment tolerance ({AlignmentTolerance}'), awaiting confirmation solve ({autoFinishGate.Consecutive}/{autoFinishGate.RequiredConsecutive}).");
                                 }
                                 if (sw.Elapsed > TimeSpan.FromMinutes(5)) {
                                     Logger.Info("Correction phase exceeded 5 minutes");
@@ -622,7 +628,11 @@ namespace NINA.Plugins.PolarAlignment.Instructions {
                                     sw.Reset();
                                 }
                                 localCTS.Token.ThrowIfCancellationRequested();
-                                await TPAPAVM.MoveCloser(progress, localCTS.Token);
+                                // While a below-tolerance result awaits confirmation, hold the motors
+                                // still so the confirmation solve measures the same state.
+                                if (autoFinishGate.Consecutive == 0) {
+                                    await TPAPAVM.MoveCloser(progress, localCTS.Token);
+                                }
                             } else {
                                 Logger.Warning("Skipping error publication and automated correction because the continuous estimate was unstable.");
                             }

--- a/PolarAlignment/NINA.Plugins.PolarAlignment.csproj
+++ b/PolarAlignment/NINA.Plugins.PolarAlignment.csproj
@@ -12,7 +12,7 @@
     <Product>NINA.Plugins</Product>
     <Description>Three Point Polar Alignment almost anywhere in the sky</Description>
     <Copyright>Copyright ©  2021-2025</Copyright>
-    <Version>2.2.6.4</Version>
+    <Version>2.2.6.5</Version>
   </PropertyGroup>
   <ItemGroup>    
     <PackageReference Include="NINA.Plugin" Version="3.1.2.9001" />    


### PR DESCRIPTION
Second of the split series from #13 (2 of 4).

## What

Automatic completion currently ends the alignment on the first solve at or below the tolerance. With solve noise of a few arcseconds, a single lucky measurement can terminate a procedure that hasn't actually converged — observed repeatedly during field testing near tight tolerances (0.35').

- Completion now requires **2 consecutive stable solves below the tolerance** (`AutoFinishGate`)
- An above-tolerance solve resets the pending confirmation
- While a confirmation is pending, `MoveCloser` is skipped so the motors hold still and the confirmation solve measures the same state (no-op for manual alignment, where no automated system is active)
- Log line shows confirmation progress (`1/2`)

## Scope

The completion decision is extracted into a small, pure `AutoFinishGate` class (public, matching how `AutomatedAdjustmentController` is exposed for tests). The correction loop change is limited to routing the existing below-tolerance branch through the gate.

This intentionally affects all alignment runs (manual included) — it only makes completion stricter by one extra confirming solve, and per the #13 review it ships as its own PR.

## Testing

- 5 dedicated unit tests for the gate: single solve doesn't finish, two consecutive do, above-tolerance resets, pending state holds corrections, threshold of 1 preserves single-solve behavior
- Full suite green (52/52)
- Field data: with this gate plus tuned OAPA corrections, testers reached 0.27'-0.45' final errors without premature termination

Changelog entry assumes merge after #14; happy to rebase/renumber as needed.
