### PR TITLE
Add OAPA self-calibration with backlash measurement and session-scoped home

### DIFF
--- a/NINA.Plugins.PolarAlignment.Test/OapaCalibrationTest.cs
+++ b/NINA.Plugins.PolarAlignment.Test/OapaCalibrationTest.cs
@@ -9,8 +9,8 @@ namespace NINA.Plugins.PolarAlignment.Test {
 
     public class OapaCalibrationGeometryTest {
 
-        private static CalibrationSolveSample Sample(double raDeg, double decDeg, double altDeg = 30) =>
-            new(raDeg, decDeg, altDeg);
+        private static CalibrationSolveSample Sample(double raDeg, double decDeg, double altDeg = 30, double azDeg = 100) =>
+            new(raDeg, decDeg, altDeg, azDeg);
 
         [Test]
         public void AngularSeparation_OneDegreeOfDec_IsOneDegree() {
@@ -43,16 +43,45 @@ namespace NINA.Plugins.PolarAlignment.Test {
         }
 
         [Test]
-        public void TangentDotProduct_AntiparallelDisplacements_IsNegative() {
-            var a1 = Sample(10, 0);
-            var a2 = Sample(10, 0.5);
-            OapaCalibrationGeometry.TangentDotProduct(a1, a2, a2, a1).Should().BeNegative();
+        public void SignedDisplacement_AltitudeRisesOnPositiveCommand_IsConsistent() {
+            var a = Sample(10, 0, altDeg: 30);
+            var b = Sample(10, 0.5, altDeg: 30.75);
+            OapaCalibrationGeometry.SignedDisplacementMatchesCommand(isAzimuthAxis: false, a, b, 45f).Should().BeTrue();
+            OapaCalibrationGeometry.SignedDisplacementMatchesCommand(isAzimuthAxis: false, a, b, -45f).Should().BeFalse();
+        }
+
+        [Test]
+        public void SignedDisplacement_AltitudeFallsOnPositiveCommand_IsInconsistent() {
+            // A physically reversed altitude axis: the field drops when commanded up.
+            var a = Sample(10, 0, altDeg: 30);
+            var b = Sample(10, -0.5, altDeg: 29.25);
+            OapaCalibrationGeometry.SignedDisplacementMatchesCommand(isAzimuthAxis: false, a, b, 45f).Should().BeFalse();
+            OapaCalibrationGeometry.SignedDisplacementMatchesCommand(isAzimuthAxis: false, a, b, -45f).Should().BeTrue();
+        }
+
+        [Test]
+        public void SignedDisplacement_AzimuthUsesTopocentricAzimuth() {
+            var a = Sample(10, 0, azDeg: 100.0);
+            var b = Sample(10.5, 0, azDeg: 100.75);
+            OapaCalibrationGeometry.SignedDisplacementMatchesCommand(isAzimuthAxis: true, a, b, 45f).Should().BeTrue();
+            OapaCalibrationGeometry.SignedDisplacementMatchesCommand(isAzimuthAxis: true, a, b, -45f).Should().BeFalse();
+        }
+
+        [Test]
+        public void SignedDisplacement_AzimuthAcrossNorth_KeepsItsSign() {
+            // 359.9° -> 0.65° is +0.75° of azimuth, not -359.25°: the wrap must not flip the verdict.
+            var a = Sample(10, 0, azDeg: 359.9);
+            var b = Sample(10.5, 0, azDeg: 0.65);
+            OapaCalibrationGeometry.SignedDisplacementMatchesCommand(isAzimuthAxis: true, a, b, 45f).Should().BeTrue();
+
+            var back = OapaCalibrationGeometry.SignedDisplacementMatchesCommand(isAzimuthAxis: true, b, a, 45f);
+            back.Should().BeFalse("0.65° -> 359.9° is negative azimuth motion");
         }
 
         [Test]
         public void ComputeAxisCalibration_CleanLegs_YieldRatioAndZeroBacklash() {
             // Commanded 45' with ratio 100 moved the sky by 45' on every leg: ratio confirmed, no backlash.
-            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 45.0, 45.0, tangentDotNegative: true);
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 45.0, 45.0, directionConsistent: true);
             r.Ratio.Should().BeApproximately(100f, 0.01f);
             r.BacklashArcmin.Should().Be(0f);
             r.Consistent.Should().BeTrue();
@@ -62,14 +91,14 @@ namespace NINA.Plugins.PolarAlignment.Test {
         [Test]
         public void ComputeAxisCalibration_ReversalShortfall_IsMeasuredAsBacklash() {
             // Clean legs 45', reversal leg only 40': 5' lost to backlash.
-            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 40.0, 45.0, tangentDotNegative: true);
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 40.0, 45.0, directionConsistent: true);
             r.BacklashArcmin.Should().BeApproximately(5f, 0.01f);
         }
 
         [Test]
         public void ComputeAxisCalibration_RatioScalesWithMeasuredMotion() {
             // Commanded 45' only moved the sky 22.5': the true ratio is double the current one.
-            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 22.5, 22.5, 22.5, tangentDotNegative: true);
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 22.5, 22.5, 22.5, directionConsistent: true);
             r.Ratio.Should().BeApproximately(200f, 0.01f);
         }
 
@@ -80,7 +109,7 @@ namespace NINA.Plugins.PolarAlignment.Test {
             // physical backlash is 2.5'. The old formula returned 5' (the shortfall scaled
             // back into the obsolete command system), which after Apply would double the
             // compensation moves.
-            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 22.5, 20.0, 22.5, tangentDotNegative: true);
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 22.5, 20.0, 22.5, directionConsistent: true);
             r.Ratio.Should().BeApproximately(200f, 0.01f);
             r.BacklashArcmin.Should().BeApproximately(2.5f, 0.01f);
         }
@@ -94,7 +123,7 @@ namespace NINA.Plugins.PolarAlignment.Test {
                 (100f, 100f, 5.0), (100f, 200f, 2.5), (200f, 100f, 10.0), (50f, 150f, 1.0) }) {
                 var clean = 45.0 * currentRatio / trueRatio;
                 var reversal = clean - physicalBacklash;
-                var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, currentRatio, clean, reversal, clean, tangentDotNegative: true);
+                var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, currentRatio, clean, reversal, clean, directionConsistent: true);
                 r.BacklashArcmin.Should().BeApproximately((float)physicalBacklash, 0.01f,
                     $"currentRatio={currentRatio}, trueRatio={trueRatio}");
             }
@@ -105,28 +134,28 @@ namespace NINA.Plugins.PolarAlignment.Test {
             // With a wrong ratio the physical legs are 22.5'; a 17.5' shortfall exceeds half
             // of the physical leg and must clamp against it, not against the commanded 45'.
             var warnings = new List<string>();
-            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 22.5, 5.0, 22.5, tangentDotNegative: true, warnings.Add);
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 22.5, 5.0, 22.5, directionConsistent: true, warnings.Add);
             r.BacklashArcmin.Should().BeApproximately(11.25f, 0.01f);
             warnings.Should().ContainSingle(w => w.Contains("clamping"));
         }
 
         [Test]
         public void ComputeAxisCalibration_LegAsymmetryAboveThreshold_IsFlagged() {
-            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 40.0, 30.0, tangentDotNegative: true);
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 40.0, 30.0, directionConsistent: true);
             r.Asymmetric.Should().BeTrue();
         }
 
         [Test]
         public void ComputeAxisCalibration_ExcessiveBacklash_IsClampedWithWarning() {
             var warnings = new List<string>();
-            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 10.0, 45.0, tangentDotNegative: true, warnings.Add);
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 10.0, 45.0, directionConsistent: true, warnings.Add);
             r.BacklashArcmin.Should().Be(22.5f);
             warnings.Should().ContainSingle(w => w.Contains("clamping"));
         }
 
         [Test]
         public void ComputeAxisCalibration_NoMeasurableMotion_Throws() {
-            var act = () => OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 0.05, 0.0, 0.05, tangentDotNegative: true);
+            var act = () => OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 0.05, 0.0, 0.05, directionConsistent: true);
             act.Should().Throw<InvalidOperationException>().WithMessage("*did not move*");
         }
     }
@@ -136,19 +165,23 @@ namespace NINA.Plugins.PolarAlignment.Test {
         /// <summary>
         /// Simulates an axis with a physical response and backlash. The backlash lives in the
         /// mechanics, so it is expressed in physical arcminutes and subtracted after the
-        /// response scaling. Solves report the accumulated physical position as a Dec offset
-        /// (1:1 for the altitude axis).
+        /// response scaling. A direction sign of -1 models physically inverted wiring: the
+        /// axis moves opposite to the commanded direction. Solves report the accumulated
+        /// physical position as a Dec offset and as topocentric altitude (1:1 for the
+        /// altitude axis).
         /// </summary>
         private sealed class FakeAxis : IOapaCalibrationMotion, IOapaCalibrationSolver {
             private readonly double responseScale;
             private readonly double physicalBacklashArcmin;
+            private readonly int directionSign;
             private double physicalPositionArcmin;
             private int lastSign;
             public readonly List<float> CommandedMoves = new();
 
-            public FakeAxis(double responseScale, double physicalBacklashArcmin) {
+            public FakeAxis(double responseScale, double physicalBacklashArcmin, int directionSign = 1) {
                 this.responseScale = responseScale;
                 this.physicalBacklashArcmin = physicalBacklashArcmin;
+                this.directionSign = directionSign;
             }
 
             public Task MoveRelative(Axis axis, float arcmin, CancellationToken token) {
@@ -159,12 +192,13 @@ namespace NINA.Plugins.PolarAlignment.Test {
                     effective = Math.Max(0, effective - physicalBacklashArcmin);
                 }
                 if (sign != 0) { lastSign = sign; }
-                physicalPositionArcmin += sign * effective;
+                physicalPositionArcmin += sign * directionSign * effective;
                 return Task.CompletedTask;
             }
 
             public Task<CalibrationSolveSample> CaptureAndSolve(CancellationToken token) {
-                return Task.FromResult(new CalibrationSolveSample(10.0, physicalPositionArcmin / 60.0, 30.0));
+                return Task.FromResult(new CalibrationSolveSample(
+                    10.0, physicalPositionArcmin / 60.0, 30.0 + physicalPositionArcmin / 60.0, 100.0));
             }
         }
 
@@ -184,6 +218,48 @@ namespace NINA.Plugins.PolarAlignment.Test {
             outcome.BacklashArcmin.Should().BeApproximately(5f, 0.5f, "backlash is physical axis arcminutes");
             outcome.Consistent.Should().BeTrue();
             outcome.Flipped.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task Calibration_InvertedPhysicalResponse_FlipsAndSucceeds() {
+            // The axis physically moves opposite to the commanded direction. The first pass
+            // must detect the direction mismatch, the auto-flip retry must succeed, and the
+            // outcome must report Flipped so the caller persists the corrected Reverse flag.
+            var axis = new FakeAxis(responseScale: 1.0, physicalBacklashArcmin: 0.0, directionSign: -1);
+            var service = new OapaCalibrationService(axis, axis);
+
+            var outcome = await service.CalibrateAxisWithAutoReverse(
+                Axis.YAxis, currentRatio: 100f, reversed: false, "Y", null, CancellationToken.None);
+
+            outcome.Flipped.Should().BeTrue("an inverted physical response must be resolved by flipping Reverse");
+            outcome.Consistent.Should().BeTrue();
+            outcome.Ratio.Should().BeApproximately(100f, 1f);
+        }
+
+        private sealed class AlwaysNegativeAxis : IOapaCalibrationMotion, IOapaCalibrationSolver {
+            private double physicalPositionArcmin;
+            public Task MoveRelative(Axis axis, float arcmin, CancellationToken token) {
+                physicalPositionArcmin -= Math.Abs(arcmin);
+                return Task.CompletedTask;
+            }
+            public Task<CalibrationSolveSample> CaptureAndSolve(CancellationToken token) {
+                return Task.FromResult(new CalibrationSolveSample(
+                    10.0, physicalPositionArcmin / 60.0, 30.0 + physicalPositionArcmin / 60.0, 100.0));
+            }
+        }
+
+        [Test]
+        public async Task Calibration_DirectionUnresolvableByFlip_ReportsInconsistent() {
+            // An axis that always drifts the same way no matter the command: flipping Reverse
+            // cannot fix it, so the outcome must surface the inconsistency without a flip.
+            var axis = new AlwaysNegativeAxis();
+            var service = new OapaCalibrationService(axis, axis);
+
+            var outcome = await service.CalibrateAxisWithAutoReverse(
+                Axis.YAxis, currentRatio: 100f, reversed: false, "Y", null, CancellationToken.None);
+
+            outcome.Flipped.Should().BeFalse();
+            outcome.Consistent.Should().BeFalse();
         }
 
         [Test]
@@ -237,7 +313,7 @@ namespace NINA.Plugins.PolarAlignment.Test {
 
         private sealed class ZenithSolver : IOapaCalibrationSolver {
             public Task<CalibrationSolveSample> CaptureAndSolve(CancellationToken token) =>
-                Task.FromResult(new CalibrationSolveSample(10.0, 0.0, 85.0));
+                Task.FromResult(new CalibrationSolveSample(10.0, 0.0, 85.0, 100.0));
         }
     }
 }

--- a/NINA.Plugins.PolarAlignment.Test/OapaCalibrationTest.cs
+++ b/NINA.Plugins.PolarAlignment.Test/OapaCalibrationTest.cs
@@ -200,6 +200,9 @@ namespace NINA.Plugins.PolarAlignment.Test {
                 return Task.FromResult(new CalibrationSolveSample(
                     10.0, physicalPositionArcmin / 60.0, 30.0 + physicalPositionArcmin / 60.0, 100.0));
             }
+
+            /// <summary>Where the axis physically sits, in arcminutes from its start.</summary>
+            public double PhysicalPositionArcmin => physicalPositionArcmin;
         }
 
         [Test]
@@ -263,15 +266,29 @@ namespace NINA.Plugins.PolarAlignment.Test {
         }
 
         [Test]
-        public async Task Calibration_NetCommandedMotionIsZero() {
+        public async Task Calibration_ReturnsAxisToItsPhysicalStart() {
+            // Supersedes the old zero-command-sum assertion: with backlash, a zero net command
+            // does not mean the axis returned. The invariant is the physical position.
             var axis = new FakeAxis(responseScale: 1.0, physicalBacklashArcmin: 0.0);
             var service = new OapaCalibrationService(axis, axis);
 
             await service.CalibrateAxisWithAutoReverse(Axis.YAxis, 100f, false, "Y", null, CancellationToken.None);
 
-            float net = 0;
-            axis.CommandedMoves.ForEach(m => net += m);
-            net.Should().Be(0f, "the axis must end where it started");
+            axis.PhysicalPositionArcmin.Should().BeApproximately(0.0, 0.6, "the axis must end where it started");
+        }
+
+        [Test]
+        public async Task Calibration_WithBacklash_ClosesLoopAgainstBaseline() {
+            // The four-move sequence loses the backlash on the reversal leg, so a zero command
+            // sum leaves the axis ~backlash away from its start. The closing move measured
+            // against the baseline solve must bring it back.
+            var axis = new FakeAxis(responseScale: 0.5, physicalBacklashArcmin: 5.0);
+            var service = new OapaCalibrationService(axis, axis);
+
+            await service.CalibrateAxisWithAutoReverse(Axis.YAxis, 100f, false, "Y", null, CancellationToken.None);
+
+            axis.PhysicalPositionArcmin.Should().BeApproximately(0.0, 0.6,
+                "closing the loop against the baseline must undo the backlash offset");
         }
 
         private sealed class FailingSolver : IOapaCalibrationSolver {
@@ -286,18 +303,63 @@ namespace NINA.Plugins.PolarAlignment.Test {
             }
         }
 
+        /// <summary>Fails exactly one solve, letting the best-effort restore solve succeed.</summary>
+        private sealed class FailOnceSolver : IOapaCalibrationSolver {
+            private readonly IOapaCalibrationSolver inner;
+            private int calls;
+            private readonly int failAtCall;
+            private readonly Exception toThrow;
+            public FailOnceSolver(IOapaCalibrationSolver inner, int failAtCall, Exception toThrow = null) {
+                this.inner = inner;
+                this.failAtCall = failAtCall;
+                this.toThrow = toThrow ?? new InvalidOperationException("solver failed");
+            }
+            public Task<CalibrationSolveSample> CaptureAndSolve(CancellationToken token) {
+                calls++;
+                if (calls == failAtCall) { throw toThrow; }
+                return inner.CaptureAndSolve(token);
+            }
+        }
+
         [Test]
-        public async Task MidSequenceFailure_DrivesAccumulatedMotionBack() {
+        public async Task MidSequenceFailure_SolverUnavailable_FallsBackToCommandSumRestore() {
             var axis = new FakeAxis(responseScale: 1.0, physicalBacklashArcmin: 0.0);
-            // Baseline and solve A succeed; solve B fails, leaving two commanded legs outstanding.
+            // Solve B and everything after it fail, so the measured restore is impossible
+            // and the commanded-sum fallback must still bring the axis home.
             var service = new OapaCalibrationService(axis, new FailingSolver(axis, failFrom: 3));
 
             var act = () => service.CalibrateAxisWithAutoReverse(Axis.YAxis, 100f, false, "Y", null, CancellationToken.None);
             await act.Should().ThrowAsync<InvalidOperationException>();
 
-            float net = 0;
-            axis.CommandedMoves.ForEach(m => net += m);
-            net.Should().Be(0f, "the restore move must return the axis to its start");
+            axis.PhysicalPositionArcmin.Should().BeApproximately(0.0, 0.6, "the fallback restore must return the axis to its start");
+        }
+
+        [Test]
+        public async Task MidSequenceFailure_WithBacklash_RestoresAgainstBaseline() {
+            // Solve C fails after the reversal leg has eaten the backlash: the commanded sum
+            // says -45' outstanding, but the axis physically sits at +50'. The restore solve
+            // succeeds, so the measured residual - not the command sum - must be driven back.
+            var axis = new FakeAxis(responseScale: 1.0, physicalBacklashArcmin: 40.0);
+            var service = new OapaCalibrationService(axis, new FailOnceSolver(axis, failAtCall: 4));
+
+            var act = () => service.CalibrateAxisWithAutoReverse(Axis.YAxis, 100f, false, "Y", null, CancellationToken.None);
+            await act.Should().ThrowAsync<InvalidOperationException>();
+
+            axis.PhysicalPositionArcmin.Should().BeApproximately(0.0, 0.6,
+                "the measured restore must undo the backlash-distorted position");
+        }
+
+        [Test]
+        public async Task Cancellation_MidSequence_RestoresAgainstBaseline() {
+            var axis = new FakeAxis(responseScale: 1.0, physicalBacklashArcmin: 40.0);
+            var service = new OapaCalibrationService(axis,
+                new FailOnceSolver(axis, failAtCall: 4, new OperationCanceledException()));
+
+            var act = () => service.CalibrateAxisWithAutoReverse(Axis.YAxis, 100f, false, "Y", null, CancellationToken.None);
+            await act.Should().ThrowAsync<OperationCanceledException>();
+
+            axis.PhysicalPositionArcmin.Should().BeApproximately(0.0, 0.6,
+                "cancellation must not strand the axis away from its start");
         }
 
         [Test]

--- a/NINA.Plugins.PolarAlignment.Test/OapaCalibrationTest.cs
+++ b/NINA.Plugins.PolarAlignment.Test/OapaCalibrationTest.cs
@@ -74,6 +74,43 @@ namespace NINA.Plugins.PolarAlignment.Test {
         }
 
         [Test]
+        public void ComputeAxisCalibration_WrongRatio_BacklashIsPhysical() {
+            // Regression for the coordinate-system bug: current ratio 100, true ratio 200.
+            // Commanded 45' legs physically move 22.5'; the reversal moves 20', so the
+            // physical backlash is 2.5'. The old formula returned 5' (the shortfall scaled
+            // back into the obsolete command system), which after Apply would double the
+            // compensation moves.
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 22.5, 20.0, 22.5, tangentDotNegative: true);
+            r.Ratio.Should().BeApproximately(200f, 0.01f);
+            r.BacklashArcmin.Should().BeApproximately(2.5f, 0.01f);
+        }
+
+        [Test]
+        public void ComputeAxisCalibration_BacklashEqualsPhysicalShortfallAcrossRatios() {
+            // Invariant: whatever the ratio error, BacklashArcmin is the physical shortfall
+            // clean - reversal, so compensating by it under the discovered ratio reproduces
+            // exactly the lost physical motion.
+            foreach (var (currentRatio, trueRatio, physicalBacklash) in new[] {
+                (100f, 100f, 5.0), (100f, 200f, 2.5), (200f, 100f, 10.0), (50f, 150f, 1.0) }) {
+                var clean = 45.0 * currentRatio / trueRatio;
+                var reversal = clean - physicalBacklash;
+                var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, currentRatio, clean, reversal, clean, tangentDotNegative: true);
+                r.BacklashArcmin.Should().BeApproximately((float)physicalBacklash, 0.01f,
+                    $"currentRatio={currentRatio}, trueRatio={trueRatio}");
+            }
+        }
+
+        [Test]
+        public void ComputeAxisCalibration_ExcessiveBacklash_ClampsAgainstPhysicalLeg() {
+            // With a wrong ratio the physical legs are 22.5'; a 17.5' shortfall exceeds half
+            // of the physical leg and must clamp against it, not against the commanded 45'.
+            var warnings = new List<string>();
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 22.5, 5.0, 22.5, tangentDotNegative: true, warnings.Add);
+            r.BacklashArcmin.Should().BeApproximately(11.25f, 0.01f);
+            warnings.Should().ContainSingle(w => w.Contains("clamping"));
+        }
+
+        [Test]
         public void ComputeAxisCalibration_LegAsymmetryAboveThreshold_IsFlagged() {
             var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 40.0, 30.0, tangentDotNegative: true);
             r.Asymmetric.Should().BeTrue();
@@ -97,30 +134,32 @@ namespace NINA.Plugins.PolarAlignment.Test {
     public class OapaCalibrationServiceTest {
 
         /// <summary>
-        /// Simulates an axis with a physical response and backlash. Solves report the
-        /// accumulated physical position as a Dec offset (1:1 for the altitude axis).
+        /// Simulates an axis with a physical response and backlash. The backlash lives in the
+        /// mechanics, so it is expressed in physical arcminutes and subtracted after the
+        /// response scaling. Solves report the accumulated physical position as a Dec offset
+        /// (1:1 for the altitude axis).
         /// </summary>
         private sealed class FakeAxis : IOapaCalibrationMotion, IOapaCalibrationSolver {
             private readonly double responseScale;
-            private readonly double backlashArcmin;
+            private readonly double physicalBacklashArcmin;
             private double physicalPositionArcmin;
             private int lastSign;
             public readonly List<float> CommandedMoves = new();
 
-            public FakeAxis(double responseScale, double backlashArcmin) {
+            public FakeAxis(double responseScale, double physicalBacklashArcmin) {
                 this.responseScale = responseScale;
-                this.backlashArcmin = backlashArcmin;
+                this.physicalBacklashArcmin = physicalBacklashArcmin;
             }
 
             public Task MoveRelative(Axis axis, float arcmin, CancellationToken token) {
                 CommandedMoves.Add(arcmin);
                 var sign = Math.Sign(arcmin);
-                double effective = Math.Abs(arcmin);
+                double effective = Math.Abs(arcmin) * responseScale;
                 if (sign != 0 && lastSign != 0 && sign != lastSign) {
-                    effective = Math.Max(0, effective - backlashArcmin);
+                    effective = Math.Max(0, effective - physicalBacklashArcmin);
                 }
                 if (sign != 0) { lastSign = sign; }
-                physicalPositionArcmin += sign * effective * responseScale;
+                physicalPositionArcmin += sign * effective;
                 return Task.CompletedTask;
             }
 
@@ -130,23 +169,26 @@ namespace NINA.Plugins.PolarAlignment.Test {
         }
 
         [Test]
-        public async Task Calibration_RecoversResponseAndBacklash() {
-            // The axis physically moves half of what is commanded and loses 5' on reversal.
-            var axis = new FakeAxis(responseScale: 0.5, backlashArcmin: 5.0);
+        public async Task Calibration_RecoversResponseAndPhysicalBacklash() {
+            // The axis physically moves half of what is commanded and its mechanics lose
+            // 5 physical arcminutes on reversal. The discovered backlash must be those
+            // 5 physical arcminutes — not the shortfall re-expressed in the obsolete
+            // command system (which would be 10').
+            var axis = new FakeAxis(responseScale: 0.5, physicalBacklashArcmin: 5.0);
             var service = new OapaCalibrationService(axis, axis);
 
             var outcome = await service.CalibrateAxisWithAutoReverse(
                 Axis.YAxis, currentRatio: 100f, reversed: false, "Y", null, CancellationToken.None);
 
             outcome.Ratio.Should().BeApproximately(200f, 1f, "half the motion means double the factor");
-            outcome.BacklashArcmin.Should().BeApproximately(5f, 0.5f);
+            outcome.BacklashArcmin.Should().BeApproximately(5f, 0.5f, "backlash is physical axis arcminutes");
             outcome.Consistent.Should().BeTrue();
             outcome.Flipped.Should().BeFalse();
         }
 
         [Test]
         public async Task Calibration_NetCommandedMotionIsZero() {
-            var axis = new FakeAxis(responseScale: 1.0, backlashArcmin: 0.0);
+            var axis = new FakeAxis(responseScale: 1.0, physicalBacklashArcmin: 0.0);
             var service = new OapaCalibrationService(axis, axis);
 
             await service.CalibrateAxisWithAutoReverse(Axis.YAxis, 100f, false, "Y", null, CancellationToken.None);
@@ -170,7 +212,7 @@ namespace NINA.Plugins.PolarAlignment.Test {
 
         [Test]
         public async Task MidSequenceFailure_DrivesAccumulatedMotionBack() {
-            var axis = new FakeAxis(responseScale: 1.0, backlashArcmin: 0.0);
+            var axis = new FakeAxis(responseScale: 1.0, physicalBacklashArcmin: 0.0);
             // Baseline and solve A succeed; solve B fails, leaving two commanded legs outstanding.
             var service = new OapaCalibrationService(axis, new FailingSolver(axis, failFrom: 3));
 
@@ -184,7 +226,7 @@ namespace NINA.Plugins.PolarAlignment.Test {
 
         [Test]
         public void BaselineNearZenith_AbortsAzimuthBeforeAnyMotion() {
-            var axis = new FakeAxis(responseScale: 1.0, backlashArcmin: 0.0);
+            var axis = new FakeAxis(responseScale: 1.0, physicalBacklashArcmin: 0.0);
             var zenithSolver = new ZenithSolver();
             var service = new OapaCalibrationService(axis, zenithSolver);
 

--- a/NINA.Plugins.PolarAlignment.Test/OapaCalibrationTest.cs
+++ b/NINA.Plugins.PolarAlignment.Test/OapaCalibrationTest.cs
@@ -1,0 +1,201 @@
+using FluentAssertions;
+using NINA.Plugins.PolarAlignment.OAPA;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Plugins.PolarAlignment.Test {
+
+    public class OapaCalibrationGeometryTest {
+
+        private static CalibrationSolveSample Sample(double raDeg, double decDeg, double altDeg = 30) =>
+            new(raDeg, decDeg, altDeg);
+
+        [Test]
+        public void AngularSeparation_OneDegreeOfDec_IsOneDegree() {
+            var a = Sample(10, 0);
+            var b = Sample(10, 1);
+            OapaCalibrationGeometry.AngularSeparationDegrees(a, b).Should().BeApproximately(1.0, 1e-6);
+        }
+
+        [Test]
+        public void AxisDisplacement_AltitudeAxis_TransfersOneToOne() {
+            var a = Sample(10, 0, altDeg: 60);
+            var b = Sample(10, 0.5, altDeg: 60);
+            OapaCalibrationGeometry.AxisDisplacementArcmin(isAzimuthAxis: false, a, b).Should().BeApproximately(30.0, 0.01);
+        }
+
+        [Test]
+        public void AxisDisplacement_AzimuthAxis_CorrectsForCosAltitude() {
+            // At altitude 60°, cos(alt)=0.5: a 30' sky displacement means 60' of axis motion.
+            var a = Sample(10, 0, altDeg: 60);
+            var b = Sample(10, 0.5, altDeg: 60);
+            OapaCalibrationGeometry.AxisDisplacementArcmin(isAzimuthAxis: true, a, b).Should().BeApproximately(60.0, 0.05);
+        }
+
+        [Test]
+        public void AxisDisplacement_AzimuthNearZenith_Throws() {
+            var a = Sample(10, 0, altDeg: 80);
+            var b = Sample(10, 0.5, altDeg: 80);
+            var act = () => OapaCalibrationGeometry.AxisDisplacementArcmin(isAzimuthAxis: true, a, b);
+            act.Should().Throw<InvalidOperationException>().WithMessage("*zenith*");
+        }
+
+        [Test]
+        public void TangentDotProduct_AntiparallelDisplacements_IsNegative() {
+            var a1 = Sample(10, 0);
+            var a2 = Sample(10, 0.5);
+            OapaCalibrationGeometry.TangentDotProduct(a1, a2, a2, a1).Should().BeNegative();
+        }
+
+        [Test]
+        public void ComputeAxisCalibration_CleanLegs_YieldRatioAndZeroBacklash() {
+            // Commanded 45' with ratio 100 moved the sky by 45' on every leg: ratio confirmed, no backlash.
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 45.0, 45.0, tangentDotNegative: true);
+            r.Ratio.Should().BeApproximately(100f, 0.01f);
+            r.BacklashArcmin.Should().Be(0f);
+            r.Consistent.Should().BeTrue();
+            r.Asymmetric.Should().BeFalse();
+        }
+
+        [Test]
+        public void ComputeAxisCalibration_ReversalShortfall_IsMeasuredAsBacklash() {
+            // Clean legs 45', reversal leg only 40': 5' lost to backlash.
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 40.0, 45.0, tangentDotNegative: true);
+            r.BacklashArcmin.Should().BeApproximately(5f, 0.01f);
+        }
+
+        [Test]
+        public void ComputeAxisCalibration_RatioScalesWithMeasuredMotion() {
+            // Commanded 45' only moved the sky 22.5': the true ratio is double the current one.
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 22.5, 22.5, 22.5, tangentDotNegative: true);
+            r.Ratio.Should().BeApproximately(200f, 0.01f);
+        }
+
+        [Test]
+        public void ComputeAxisCalibration_LegAsymmetryAboveThreshold_IsFlagged() {
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 40.0, 30.0, tangentDotNegative: true);
+            r.Asymmetric.Should().BeTrue();
+        }
+
+        [Test]
+        public void ComputeAxisCalibration_ExcessiveBacklash_IsClampedWithWarning() {
+            var warnings = new List<string>();
+            var r = OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 45.0, 10.0, 45.0, tangentDotNegative: true, warnings.Add);
+            r.BacklashArcmin.Should().Be(22.5f);
+            warnings.Should().ContainSingle(w => w.Contains("clamping"));
+        }
+
+        [Test]
+        public void ComputeAxisCalibration_NoMeasurableMotion_Throws() {
+            var act = () => OapaCalibrationGeometry.ComputeAxisCalibration(45f, 100f, 0.05, 0.0, 0.05, tangentDotNegative: true);
+            act.Should().Throw<InvalidOperationException>().WithMessage("*did not move*");
+        }
+    }
+
+    public class OapaCalibrationServiceTest {
+
+        /// <summary>
+        /// Simulates an axis with a physical response and backlash. Solves report the
+        /// accumulated physical position as a Dec offset (1:1 for the altitude axis).
+        /// </summary>
+        private sealed class FakeAxis : IOapaCalibrationMotion, IOapaCalibrationSolver {
+            private readonly double responseScale;
+            private readonly double backlashArcmin;
+            private double physicalPositionArcmin;
+            private int lastSign;
+            public readonly List<float> CommandedMoves = new();
+
+            public FakeAxis(double responseScale, double backlashArcmin) {
+                this.responseScale = responseScale;
+                this.backlashArcmin = backlashArcmin;
+            }
+
+            public Task MoveRelative(Axis axis, float arcmin, CancellationToken token) {
+                CommandedMoves.Add(arcmin);
+                var sign = Math.Sign(arcmin);
+                double effective = Math.Abs(arcmin);
+                if (sign != 0 && lastSign != 0 && sign != lastSign) {
+                    effective = Math.Max(0, effective - backlashArcmin);
+                }
+                if (sign != 0) { lastSign = sign; }
+                physicalPositionArcmin += sign * effective * responseScale;
+                return Task.CompletedTask;
+            }
+
+            public Task<CalibrationSolveSample> CaptureAndSolve(CancellationToken token) {
+                return Task.FromResult(new CalibrationSolveSample(10.0, physicalPositionArcmin / 60.0, 30.0));
+            }
+        }
+
+        [Test]
+        public async Task Calibration_RecoversResponseAndBacklash() {
+            // The axis physically moves half of what is commanded and loses 5' on reversal.
+            var axis = new FakeAxis(responseScale: 0.5, backlashArcmin: 5.0);
+            var service = new OapaCalibrationService(axis, axis);
+
+            var outcome = await service.CalibrateAxisWithAutoReverse(
+                Axis.YAxis, currentRatio: 100f, reversed: false, "Y", null, CancellationToken.None);
+
+            outcome.Ratio.Should().BeApproximately(200f, 1f, "half the motion means double the factor");
+            outcome.BacklashArcmin.Should().BeApproximately(5f, 0.5f);
+            outcome.Consistent.Should().BeTrue();
+            outcome.Flipped.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task Calibration_NetCommandedMotionIsZero() {
+            var axis = new FakeAxis(responseScale: 1.0, backlashArcmin: 0.0);
+            var service = new OapaCalibrationService(axis, axis);
+
+            await service.CalibrateAxisWithAutoReverse(Axis.YAxis, 100f, false, "Y", null, CancellationToken.None);
+
+            float net = 0;
+            axis.CommandedMoves.ForEach(m => net += m);
+            net.Should().Be(0f, "the axis must end where it started");
+        }
+
+        private sealed class FailingSolver : IOapaCalibrationSolver {
+            private readonly IOapaCalibrationSolver inner;
+            private int calls;
+            private readonly int failFrom;
+            public FailingSolver(IOapaCalibrationSolver inner, int failFrom) { this.inner = inner; this.failFrom = failFrom; }
+            public Task<CalibrationSolveSample> CaptureAndSolve(CancellationToken token) {
+                calls++;
+                if (calls >= failFrom) { throw new InvalidOperationException("solver failed"); }
+                return inner.CaptureAndSolve(token);
+            }
+        }
+
+        [Test]
+        public async Task MidSequenceFailure_DrivesAccumulatedMotionBack() {
+            var axis = new FakeAxis(responseScale: 1.0, backlashArcmin: 0.0);
+            // Baseline and solve A succeed; solve B fails, leaving two commanded legs outstanding.
+            var service = new OapaCalibrationService(axis, new FailingSolver(axis, failFrom: 3));
+
+            var act = () => service.CalibrateAxisWithAutoReverse(Axis.YAxis, 100f, false, "Y", null, CancellationToken.None);
+            await act.Should().ThrowAsync<InvalidOperationException>();
+
+            float net = 0;
+            axis.CommandedMoves.ForEach(m => net += m);
+            net.Should().Be(0f, "the restore move must return the axis to its start");
+        }
+
+        [Test]
+        public void BaselineNearZenith_AbortsAzimuthBeforeAnyMotion() {
+            var axis = new FakeAxis(responseScale: 1.0, backlashArcmin: 0.0);
+            var zenithSolver = new ZenithSolver();
+            var service = new OapaCalibrationService(axis, zenithSolver);
+
+            var act = () => service.CalibrateAxisWithAutoReverse(Axis.XAxis, 100f, false, "X", null, CancellationToken.None);
+            act.Should().ThrowAsync<InvalidOperationException>();
+            axis.CommandedMoves.Should().BeEmpty("no motion may be commanded when the baseline field is unusable");
+        }
+
+        private sealed class ZenithSolver : IOapaCalibrationSolver {
+            public Task<CalibrationSolveSample> CaptureAndSolve(CancellationToken token) =>
+                Task.FromResult(new CalibrationSolveSample(10.0, 0.0, 85.0));
+        }
+    }
+}

--- a/NINA.Plugins.PolarAlignment.Test/OapaCameraBlockTest.cs
+++ b/NINA.Plugins.PolarAlignment.Test/OapaCameraBlockTest.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+using NINA.Core.Model;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Equipment.Model;
+using NINA.Image.Interfaces;
+using NINA.Plugins.PolarAlignment.OAPA;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Plugins.PolarAlignment.Test {
+
+    /// <summary>
+    /// Exercises the camera capture-block coordination of the OAPA self-calibration through
+    /// the production command path: a busy camera must abort before any motion, and a free
+    /// camera must be blocked for the whole run and released again even when it fails.
+    /// </summary>
+    public class OapaCameraBlockTest {
+
+        private sealed class FakeCameraMediator : ICameraMediator {
+            public bool Free = true;
+            public readonly List<string> Events = new();
+
+            public int RegisterCount => Events.FindAll(e => e == "register").Count;
+            public int ReleaseCount => Events.FindAll(e => e == "release").Count;
+
+            public bool IsFreeToCapture(ICameraConsumer cameraConsumer) => Free;
+            public bool IsFreeToCapture(object cameraConsumer) => Free;
+            public void RegisterCaptureBlock(ICameraConsumer cameraConsumer) => Events.Add("register");
+            public void RegisterCaptureBlock(object cameraConsumer) => Events.Add("register");
+            public void ReleaseCaptureBlock(ICameraConsumer cameraConsumer) => Events.Add("release");
+            public void ReleaseCaptureBlock(object cameraConsumer) => Events.Add("release");
+
+            // Everything below is unused plumbing required by the interface.
+            public Task Capture(CaptureSequence sequence, CancellationToken token, IProgress<ApplicationStatus> progress) => throw new NotImplementedException();
+            public IAsyncEnumerable<IExposureData> LiveView(CancellationToken token) => throw new NotImplementedException();
+            public IAsyncEnumerable<IExposureData> LiveView(CaptureSequence sequence, CancellationToken token) => throw new NotImplementedException();
+            public Task<IExposureData> Download(CancellationToken token) => throw new NotImplementedException();
+            public void AbortExposure() => throw new NotImplementedException();
+            public void SetReadoutMode(short mode) => throw new NotImplementedException();
+            public void SetReadoutModeForNormalImages(short mode) => throw new NotImplementedException();
+            public void SetBinning(short x, short y) => throw new NotImplementedException();
+            public void SetDewHeater(bool onOff) => throw new NotImplementedException();
+            public bool AtTargetTemp => throw new NotImplementedException();
+            public double TargetTemp => throw new NotImplementedException();
+            public Task<bool> CoolCamera(double temperature, TimeSpan duration, IProgress<ApplicationStatus> progress, CancellationToken ct) => throw new NotImplementedException();
+            public Task<bool> WarmCamera(TimeSpan duration, IProgress<ApplicationStatus> progress, CancellationToken ct) => throw new NotImplementedException();
+            public void SetUSBLimit(int usbLimit) => throw new NotImplementedException();
+            public void RegisterConsumer(ICameraConsumer consumer) => throw new NotImplementedException();
+            public void RemoveConsumer(ICameraConsumer consumer) => throw new NotImplementedException();
+            public Task<IList<string>> Rescan() => throw new NotImplementedException();
+            public Task<bool> Connect() => throw new NotImplementedException();
+            public Task Disconnect() => throw new NotImplementedException();
+            public void Broadcast(CameraInfo deviceInfo) => throw new NotImplementedException();
+            public CameraInfo GetInfo() => throw new NotImplementedException();
+            public string Action(string actionName, string actionParameters) => throw new NotImplementedException();
+            public string SendCommandString(string command, bool raw) => throw new NotImplementedException();
+            public bool SendCommandBool(string command, bool raw) => throw new NotImplementedException();
+            public void SendCommandBlind(string command, bool raw) => throw new NotImplementedException();
+            public IDevice GetDevice() => throw new NotImplementedException();
+            public void RegisterHandler(ICameraVM handler) => throw new NotImplementedException();
+
+            public event Func<object, EventArgs, Task> DownloadTimeout { add { } remove { } }
+            public event Func<object, EventArgs, Task> Connected { add { } remove { } }
+            public event Func<object, EventArgs, Task> Disconnected { add { } remove { } }
+        }
+
+        private sealed class FakeSystem : IPolarAlignmentSystem {
+            public readonly List<(Axis axis, float move)> RelativeMoves = new();
+            public readonly List<(Axis axis, float target)> AbsoluteMoves = new();
+
+            public bool Connected => true;
+            public string Status => "Idle";
+            public float XPosition1 => 0;
+            public float YPosition1 => 0;
+            public float ZPosition1 => 0;
+            public float XGearRatio { get; set; } = 1;
+            public float YGearRatio { get; set; } = 1;
+            public float ZGearRatio { get; set; } = 1;
+            public LastDirection XLastDirection => LastDirection.Positive;
+            public LastDirection YLastDirection => LastDirection.Positive;
+            public LastDirection ZLastDirection => LastDirection.Positive;
+
+            public Task MoveRelative(Axis axis, int speed, float position, CancellationToken token) {
+                RelativeMoves.Add((axis, position));
+                return Task.CompletedTask;
+            }
+
+            public Task MoveAbsolute(Axis axis, int speed, float position, CancellationToken token) {
+                AbsoluteMoves.Add((axis, position));
+                return Task.CompletedTask;
+            }
+
+            public Task RefreshStatus(CancellationToken token) => Task.CompletedTask;
+            public void Dispose() { }
+        }
+
+        private static (UniversalPolarAlignmentOAPAVM vm, FakeSystem system, FakeCameraMediator camera) Vm() {
+            var camera = new FakeCameraMediator();
+            var vm = new UniversalPolarAlignmentOAPAVM(null, null, null, null, camera);
+            var system = new FakeSystem();
+            vm.upa = system;
+            return (vm, system, camera);
+        }
+
+        [Test]
+        public async Task Calibration_CameraBusy_AbortsBeforeAnyMotion() {
+            var (vm, system, camera) = Vm();
+            camera.Free = false;
+
+            await vm.CalibrateGearRatios(CancellationToken.None);
+
+            system.RelativeMoves.Should().BeEmpty();
+            system.AbsoluteMoves.Should().BeEmpty();
+            camera.RegisterCount.Should().Be(0, "a refused calibration must not block the camera");
+            vm.CalibrationStatus.Should().Be("Camera busy - calibration not started");
+            vm.CalibrationRunning.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task Calibration_RegistersAndReleasesCaptureBlock_EvenOnFailure() {
+            // The null-mediator plate-solve sampler fails at the baseline solve, so this run
+            // takes the failure path: the capture block must still be released exactly once.
+            var (vm, _, camera) = Vm();
+
+            await vm.CalibrateGearRatios(CancellationToken.None);
+
+            camera.Events.Should().Equal("register", "release");
+            vm.CalibrationStatus.Should().StartWith("Failed");
+        }
+
+        [Test]
+        public void CanCalibrate_RequiresFreeCamera() {
+            var (vm, _, camera) = Vm();
+            vm.Connected = true;
+
+            camera.Free = false;
+            vm.CanCalibrate().Should().BeFalse("a busy camera must disable the calibrate command");
+
+            camera.Free = true;
+            vm.CanCalibrate().Should().BeTrue();
+        }
+    }
+}

--- a/NINA.Plugins.PolarAlignment.Test/OapaHomePositionTest.cs
+++ b/NINA.Plugins.PolarAlignment.Test/OapaHomePositionTest.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using NINA.Plugins.PolarAlignment.OAPA;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Plugins.PolarAlignment.Test {
+
+    /// <summary>
+    /// The stored home must survive gear-ratio changes: Set Home marks a physical controller
+    /// position, so Go Home has to return there no matter which calibration factor is active
+    /// when it runs — after manual factor edits as well as after applying a calibration.
+    /// </summary>
+    public class OapaHomePositionTest {
+
+        private sealed class FakeSystem : IPolarAlignmentSystem {
+            public readonly List<(Axis axis, float target)> AbsoluteMoves = new();
+
+            public bool Connected => true;
+            public string Status => "Idle";
+            public float XPosition1 => 0;
+            public float YPosition1 => 0;
+            public float ZPosition1 => 0;
+            public float XGearRatio { get; set; } = 1;
+            public float YGearRatio { get; set; } = 1;
+            public float ZGearRatio { get; set; } = 1;
+            public LastDirection XLastDirection => LastDirection.Positive;
+            public LastDirection YLastDirection => LastDirection.Positive;
+            public LastDirection ZLastDirection => LastDirection.Positive;
+
+            public Task MoveRelative(Axis axis, int speed, float position, CancellationToken token) => Task.CompletedTask;
+
+            public Task MoveAbsolute(Axis axis, int speed, float position, CancellationToken token) {
+                AbsoluteMoves.Add((axis, position));
+                return Task.CompletedTask;
+            }
+
+            public Task RefreshStatus(CancellationToken token) => Task.CompletedTask;
+            public void Dispose() { }
+        }
+
+        private static (UniversalPolarAlignmentOAPAVM vm, FakeSystem system) Vm(float xRatio, float yRatio) {
+            var vm = new UniversalPolarAlignmentOAPAVM(null, null, null, null, null);
+            var system = new FakeSystem();
+            vm.upa = system;
+            vm.XGearRatio = xRatio;
+            vm.YGearRatio = yRatio;
+            return (vm, system);
+        }
+
+        [Test]
+        public async Task GoHome_AfterManualXRatioEdit_ReturnsToSameControllerPosition() {
+            var (vm, system) = Vm(xRatio: 100, yRatio: 100);
+            vm.PositionX = 2f;   // controller position 200
+            vm.PositionY = 0f;
+            vm.SetHome();
+
+            vm.XGearRatio = 200;
+            await vm.GoHome(CancellationToken.None);
+
+            // 1 x 200 drives the controller back to 200; the stale logical value would command 2 x 200 = 400.
+            system.AbsoluteMoves.Should().Equal((Axis.XAxis, 1f), (Axis.YAxis, 0f));
+        }
+
+        [Test]
+        public async Task GoHome_AfterManualYRatioEdit_ReturnsToSameControllerPosition() {
+            var (vm, system) = Vm(xRatio: 100, yRatio: 100);
+            vm.PositionX = 0f;
+            vm.PositionY = 3f;   // controller position 300
+            vm.SetHome();
+
+            vm.YGearRatio = 300;
+            await vm.GoHome(CancellationToken.None);
+
+            system.AbsoluteMoves.Should().Equal((Axis.XAxis, 0f), (Axis.YAxis, 1f));
+        }
+
+        [Test]
+        public async Task GoHome_AfterApplyCalibration_ReturnsToSameControllerPositionOnBothAxes() {
+            var (vm, system) = Vm(xRatio: 100, yRatio: 100);
+            vm.PositionX = 2f;   // controller position 200
+            vm.PositionY = 4f;   // controller position 400
+            vm.SetHome();
+
+            vm.DiscoveredXRatio = 200;
+            vm.DiscoveredYRatio = 400;
+            vm.DiscoveredXBacklash = 0f;
+            vm.DiscoveredYBacklash = 0f;
+            vm.HasCalibrationResult = true;
+            vm.ApplyCalibration();
+
+            await vm.GoHome(CancellationToken.None);
+
+            system.AbsoluteMoves.Should().Equal((Axis.XAxis, 1f), (Axis.YAxis, 1f));
+        }
+
+        [Test]
+        public void HomeDisplay_TracksRatioChanges_WhileHomeIsSet() {
+            var (vm, _) = Vm(xRatio: 100, yRatio: 100);
+            vm.PositionX = 2f;
+            vm.PositionY = 4f;
+            vm.SetHome();
+            vm.HomeX.Should().Be(2f);
+            vm.HomeY.Should().Be(4f);
+
+            // The panel shows Home next to the logical position, so the displayed value must
+            // be re-expressed under the new factor while it keeps marking the same physical spot.
+            vm.XGearRatio = 200;
+            vm.YGearRatio = 400;
+            vm.HomeX.Should().Be(1f);
+            vm.HomeY.Should().Be(1f);
+        }
+    }
+}

--- a/NINA.Plugins.PolarAlignment.Test/UniversalPolarAlignmentVMBacklashTest.cs
+++ b/NINA.Plugins.PolarAlignment.Test/UniversalPolarAlignmentVMBacklashTest.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using NINA.Plugins.PolarAlignment.Avalon;
+using NINA.Plugins.PolarAlignment.OAPA;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Plugins.PolarAlignment.Test {
+
+    /// <summary>
+    /// Exercises the backlash-clearing wiring through the production movement paths of the
+    /// real view models, with a recording fake standing in for the controller hardware.
+    /// </summary>
+    public class UniversalPolarAlignmentVMBacklashTest {
+
+        private sealed class FakeSystem : IPolarAlignmentSystem {
+            public readonly List<(Axis axis, float move)> RelativeMoves = new();
+            public readonly List<(Axis axis, float target)> AbsoluteMoves = new();
+
+            public bool Connected => true;
+            public string Status => "Idle";
+            public float XPosition1 => 0;
+            public float YPosition1 => 0;
+            public float ZPosition1 => 0;
+            public float XGearRatio { get; set; } = 1;
+            public float YGearRatio { get; set; } = 1;
+            public float ZGearRatio { get; set; } = 1;
+            public LastDirection XLastDirection { get; private set; } = LastDirection.Positive;
+            public LastDirection YLastDirection { get; private set; } = LastDirection.Positive;
+            public LastDirection ZLastDirection { get; private set; } = LastDirection.Positive;
+
+            public Task MoveRelative(Axis axis, int speed, float position, CancellationToken token) {
+                RelativeMoves.Add((axis, position));
+                Track(axis, position);
+                return Task.CompletedTask;
+            }
+
+            public Task MoveAbsolute(Axis axis, int speed, float position, CancellationToken token) {
+                AbsoluteMoves.Add((axis, position));
+                Track(axis, position);
+                return Task.CompletedTask;
+            }
+
+            private void Track(Axis axis, float signedMotion) {
+                var direction = signedMotion >= 0 ? LastDirection.Positive : LastDirection.Negative;
+                switch (axis) {
+                    case Axis.XAxis: XLastDirection = direction; break;
+                    case Axis.YAxis: YLastDirection = direction; break;
+                    case Axis.ZAxis: ZLastDirection = direction; break;
+                }
+            }
+
+            public Task RefreshStatus(CancellationToken token) => Task.CompletedTask;
+            public void Dispose() { }
+        }
+
+        private static (UniversalPolarAlignmentOAPAVM vm, FakeSystem system) OapaVm(float xCompensation, float yCompensation) {
+            var vm = new UniversalPolarAlignmentOAPAVM(null, null, null, null);
+            var system = new FakeSystem();
+            vm.upa = system;
+            vm.ReverseAzimuth = false;
+            vm.ReverseAltitude = false;
+            vm.XBacklashCompensation = xCompensation;
+            vm.YBacklashCompensation = yCompensation;
+            return (vm, system);
+        }
+
+        [Test]
+        public async Task TryNudgeY_OnReversal_ClearsBacklashWithAltitudeCompensation() {
+            var (vm, system) = OapaVm(xCompensation: 3f, yCompensation: 5f);
+
+            (await vm.TryNudgeY(15, CancellationToken.None)).Should().BeTrue();
+            system.RelativeMoves.Clear();
+
+            (await vm.TryNudgeY(-15, CancellationToken.None)).Should().BeTrue();
+
+            var expected = BacklashCompensationPlanner.CreateSequence(5f, LastDirection.Negative);
+            system.RelativeMoves.Should().Equal(
+                (Axis.YAxis, -15f),
+                (Axis.YAxis, expected.FirstMove),
+                (Axis.YAxis, expected.SecondMove));
+        }
+
+        [Test]
+        public async Task TryNudgeY_SameDirection_DoesNotClear() {
+            var (vm, system) = OapaVm(xCompensation: 3f, yCompensation: 5f);
+
+            await vm.TryNudgeY(15, CancellationToken.None);
+            system.RelativeMoves.Clear();
+
+            await vm.TryNudgeY(15, CancellationToken.None);
+
+            system.RelativeMoves.Should().Equal((Axis.YAxis, 15f));
+        }
+
+        [Test]
+        public async Task MoveY_OnReversal_ClearsBacklashWithAltitudeCompensation() {
+            var (vm, system) = OapaVm(xCompensation: 3f, yCompensation: 5f);
+
+            await vm.TryNudgeY(15, CancellationToken.None);
+            system.RelativeMoves.Clear();
+
+            vm.TargetPositionY = -100;
+            await vm.MoveY(CancellationToken.None);
+
+            var expected = BacklashCompensationPlanner.CreateSequence(5f, LastDirection.Negative);
+            system.AbsoluteMoves.Should().Equal((Axis.YAxis, -100f));
+            system.RelativeMoves.Should().Equal(
+                (Axis.YAxis, expected.FirstMove),
+                (Axis.YAxis, expected.SecondMove));
+        }
+
+        [Test]
+        public async Task TryNudgeX_OnReversal_SequenceUnchangedByYWiring() {
+            var (vm, system) = OapaVm(xCompensation: 3f, yCompensation: 5f);
+
+            await vm.TryNudgeX(15, CancellationToken.None);
+            system.RelativeMoves.Clear();
+
+            await vm.TryNudgeX(-15, CancellationToken.None);
+
+            var expected = BacklashCompensationPlanner.CreateSequence(3f, LastDirection.Negative);
+            system.RelativeMoves.Should().Equal(
+                (Axis.XAxis, -15f),
+                (Axis.XAxis, expected.FirstMove),
+                (Axis.XAxis, expected.SecondMove));
+        }
+
+        [Test]
+        public async Task TryNudgeY_AvalonDefaultPolicy_NeverClears() {
+            // The Avalon UPAS altitude axis does not use backlash compensation: the base
+            // policy must keep Y reversals as plain moves even with X compensation set.
+            var vm = new UniversalPolarAlignmentVM(null);
+            var system = new FakeSystem();
+            vm.upa = system;
+            vm.ReverseAltitude = false;
+            vm.XBacklashCompensation = 3f;
+
+            await vm.TryNudgeY(15, CancellationToken.None);
+            system.RelativeMoves.Clear();
+
+            await vm.TryNudgeY(-15, CancellationToken.None);
+
+            system.RelativeMoves.Should().Equal((Axis.YAxis, -15f));
+        }
+
+        [Test]
+        public async Task TryNudgeY_ZeroCompensation_DoesNotClear() {
+            var (vm, system) = OapaVm(xCompensation: 3f, yCompensation: 0f);
+
+            await vm.TryNudgeY(15, CancellationToken.None);
+            system.RelativeMoves.Clear();
+
+            await vm.TryNudgeY(-15, CancellationToken.None);
+
+            system.RelativeMoves.Should().Equal((Axis.YAxis, -15f));
+        }
+    }
+}

--- a/NINA.Plugins.PolarAlignment.Test/UniversalPolarAlignmentVMBacklashTest.cs
+++ b/NINA.Plugins.PolarAlignment.Test/UniversalPolarAlignmentVMBacklashTest.cs
@@ -55,7 +55,7 @@ namespace NINA.Plugins.PolarAlignment.Test {
         }
 
         private static (UniversalPolarAlignmentOAPAVM vm, FakeSystem system) OapaVm(float xCompensation, float yCompensation) {
-            var vm = new UniversalPolarAlignmentOAPAVM(null, null, null, null);
+            var vm = new UniversalPolarAlignmentOAPAVM(null, null, null, null, null);
             var system = new FakeSystem();
             vm.upa = system;
             vm.ReverseAzimuth = false;

--- a/PolarAlignment/Changelog.md
+++ b/PolarAlignment/Changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 2.2.6.6
+- OAPA: added **Self-Calibration** to the OAPA control dock. For each axis the routine runs a large-lever sequence (baseline solve, priming leg, forward leg, reversal leg, reverse leg of 45' each; net commanded motion is zero) and derives the calibration factor from the two backlash-free legs and the **mechanical backlash** from the reversal-leg shortfall. Apply persists both.
+- OAPA calibration: azimuth displacements are corrected by **cos(field altitude)** — a base rotation of θ moves a field at altitude h by only θ·cos(h) — so the discovered values no longer depend on where the scope points. Calibration refuses to run the azimuth axis when the field is too close to the zenith (cos(alt) < 0.25).
+- OAPA calibration: baseline solve before any motion (an unsolvable field aborts at zero cost), best-effort position restore on mid-sequence failure, forward/reverse leg asymmetry warning (>20%), and automatic Reverse Az/Alt flag correction with a single verified retry.
+- OAPA: separate **altitude-axis backlash** value (measured by the calibration, editable in the Altitude Motor Settings panel).
+- OAPA: **Home Position** panel (Set Home / Go Home). Home is session-scoped: the controller's position counter restarts at 0 on power-up, so the stored home is discarded on every reconnect instead of persisting stale coordinates.
+- UI: renamed "GearRatio" to "Calibration Factor" in the OAPA panels (the value is a software calibration constant, not a mechanical reduction). Settings keys unchanged.
+
 ## Version 2.2.6.5
 - Automatic completion now requires 2 consecutive solves below the alignment tolerance before finishing, so a single lucky solve cannot end a non-converged procedure. While a below-tolerance result awaits confirmation, automated corrections hold still so the confirmation solve measures the same state.
 

--- a/PolarAlignment/NINA.Plugins.PolarAlignment.csproj
+++ b/PolarAlignment/NINA.Plugins.PolarAlignment.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0-windows7.0</TargetFramework>
     <OutputType>Library</OutputType>
@@ -12,7 +12,7 @@
     <Product>NINA.Plugins</Product>
     <Description>Three Point Polar Alignment almost anywhere in the sky</Description>
     <Copyright>Copyright ©  2021-2025</Copyright>
-    <Version>2.2.6.5</Version>
+    <Version>2.2.6.6</Version>
   </PropertyGroup>
   <ItemGroup>    
     <PackageReference Include="NINA.Plugin" Version="3.1.2.9001" />    

--- a/PolarAlignment/OAPA/OAPAControlPanel.xaml
+++ b/PolarAlignment/OAPA/OAPAControlPanel.xaml
@@ -8,10 +8,12 @@
              mc:Ignorable="d">
 
     <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <s:String x:Key="OAPASpeedToolTip">Speed value passed to OAPA move commands for this axis.</s:String>
         <s:String x:Key="OAPAGearRatioToolTip">Scale factor used when converting between OAPA motor units and the axis units shown by TPPA.</s:String>
         <s:String x:Key="OAPARunCurrentToolTip">Run-current value, in milliamps, sent to the OAPA controller for this axis.</s:String>
         <s:String x:Key="OAPAHoldPercentToolTip">Hold-current percentage sent to the OAPA controller for this axis.</s:String>
+        <s:String x:Key="OAPAYBacklashToolTip">Altitude-axis mechanical backlash in arcminutes, measured automatically by the Self-Calibration. Specific to OAPA platforms.</s:String>
     </UserControl.Resources>
 
     <StackPanel>
@@ -53,7 +55,7 @@
                             </x:Array>
                         </ComboBox.ItemsSource>
                     </ComboBox>
-                    <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" Margin="5" ToolTip="{StaticResource OAPAGearRatioToolTip}">GearRatio</TextBlock>
+                    <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" Margin="5" ToolTip="{StaticResource OAPAGearRatioToolTip}">Calibration Factor</TextBlock>
                     <TextBox Grid.Row="0" Grid.Column="3" VerticalAlignment="Center" Margin="5" Text="{Binding XGearRatio}" ToolTip="{StaticResource OAPAGearRatioToolTip}" />
 
                     <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="5" ToolTip="{StaticResource OAPARunCurrentToolTip}">Run (mA)</TextBlock>
@@ -67,6 +69,7 @@
             <GroupBox Grid.Column="1" Header="Altitude Motor Settings">
                 <Grid>
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
@@ -94,13 +97,16 @@
                             </x:Array>
                         </ComboBox.ItemsSource>
                     </ComboBox>
-                    <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" Margin="5" ToolTip="{StaticResource OAPAGearRatioToolTip}">GearRatio</TextBlock>
+                    <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" Margin="5" ToolTip="{StaticResource OAPAGearRatioToolTip}">Calibration Factor</TextBlock>
                     <TextBox Grid.Row="0" Grid.Column="3" VerticalAlignment="Center" Margin="5" Text="{Binding YGearRatio}" ToolTip="{StaticResource OAPAGearRatioToolTip}" />
 
                     <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="5" ToolTip="{StaticResource OAPARunCurrentToolTip}">Run (mA)</TextBlock>
                     <TextBox Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Margin="5" Text="{Binding YRunCurrent}" ToolTip="{StaticResource OAPARunCurrentToolTip}" />
                     <TextBlock Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" Margin="5" ToolTip="{StaticResource OAPAHoldPercentToolTip}">Hold %</TextBlock>
                     <TextBox Grid.Row="1" Grid.Column="3" VerticalAlignment="Center" Margin="5" Text="{Binding YHoldPercent}" ToolTip="{StaticResource OAPAHoldPercentToolTip}" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="5" ToolTip="{StaticResource OAPAYBacklashToolTip}">Backlash (')</TextBlock>
+                    <TextBox Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="5" Text="{Binding YBacklashCompensation}" ToolTip="{StaticResource OAPAYBacklashToolTip}" />
                 </Grid>
             </GroupBox>
         </Grid>
@@ -207,5 +213,92 @@
                 </Grid>
             </GroupBox>
         </Grid>
+
+        <!-- Home Position - Only Visible When Connected -->
+        <GroupBox Header="Home Position"
+                  Margin="0,5,0,0"
+                  Visibility="{Binding Connected, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Button Grid.Column="0" Height="25" Margin="5" Command="{Binding GoHomeCommand}"
+                        ToolTip="Move both axes back to the home position stored in this session">Go Home</Button>
+                <Button Grid.Column="1" Height="25" Margin="5" Command="{Binding SetHomeCommand}"
+                        ToolTip="Store the current axis positions as the home position for this session. The controller's position counter restarts at 0 on power-up, so the stored home is discarded on reconnect.">Set Home</Button>
+                <StackPanel Grid.Column="2" Margin="5" Orientation="Horizontal" VerticalAlignment="Center"
+                            Visibility="{Binding HasHome, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <TextBlock Text="X: " />
+                    <TextBlock Text="{Binding HomeX, StringFormat=N2}" />
+                    <TextBlock Text="  Y: " />
+                    <TextBlock Text="{Binding HomeY, StringFormat=N2}" />
+                </StackPanel>
+            </Grid>
+        </GroupBox>
+
+        <!-- Self-Calibration Panel - Only Visible When Connected -->
+        <GroupBox Header="Self-Calibration"
+                  Margin="0,5,0,0"
+                  Visibility="{Binding Connected, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <StackPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Button Grid.Column="0" Height="25" Margin="5" Padding="10,0" Command="{Binding CalibrateGearRatiosCommand}">Calibrate</Button>
+                    <TextBlock Grid.Column="1" Margin="5" VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding CalibrationStatus}" />
+                </Grid>
+
+                <Grid Margin="5,5,5,0" Visibility="{Binding HasCalibrationResult, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.ColumnSpan="4" Margin="0,0,0,10"
+                               FontWeight="Bold" FontSize="14"
+                               Text="&#x2705; Calibration complete &#x2014; review the discovered values below and click Apply or Discard." />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,10,5" Text="Discovered X factor:" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Margin="0,0,20,5" Text="{Binding DiscoveredXRatio, StringFormat=F2}" FontWeight="Bold" />
+                    <TextBlock Grid.Row="1" Grid.Column="2" Margin="0,0,10,5" Text="Current X factor:" />
+                    <TextBlock Grid.Row="1" Grid.Column="3" Margin="0,0,0,5" Text="{Binding XGearRatio, StringFormat=F2}" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Margin="0,0,10,5" Text="Discovered Y factor:" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Margin="0,0,20,5" Text="{Binding DiscoveredYRatio, StringFormat=F2}" FontWeight="Bold" />
+                    <TextBlock Grid.Row="2" Grid.Column="2" Margin="0,0,10,5" Text="Current Y factor:" />
+                    <TextBlock Grid.Row="2" Grid.Column="3" Margin="0,0,0,5" Text="{Binding YGearRatio, StringFormat=F2}" />
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" Margin="0,0,10,5" Text="Discovered X backlash (arcmin):" />
+                    <TextBlock Grid.Row="3" Grid.Column="1" Margin="0,0,20,5" Text="{Binding DiscoveredXBacklash, StringFormat=F2}" FontWeight="Bold" />
+                    <TextBlock Grid.Row="3" Grid.Column="2" Margin="0,0,10,5" Text="Discovered Y backlash (arcmin):" />
+                    <TextBlock Grid.Row="3" Grid.Column="3" Margin="0,0,0,5" Text="{Binding DiscoveredYBacklash, StringFormat=F2}" FontWeight="Bold" />
+
+                    <TextBlock Grid.Row="4" Grid.ColumnSpan="4" Margin="0,5,0,5" TextWrapping="Wrap" Text="{Binding CalibrationConsistencyMessage}" FontStyle="Italic" />
+
+                    <Grid Grid.Row="5" Grid.ColumnSpan="4" Margin="0,5,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+                        <Button Grid.Column="0" Height="25" Margin="0,0,2.5,0" Command="{Binding ApplyCalibrationCommand}">Apply</Button>
+                        <Button Grid.Column="1" Height="25" Margin="2.5,0,0,0" Command="{Binding DiscardCalibrationCommand}">Discard</Button>
+                    </Grid>
+                </Grid>
+            </StackPanel>
+        </GroupBox>
     </StackPanel>
 </UserControl>

--- a/PolarAlignment/OAPA/OapaCalibrationGeometry.cs
+++ b/PolarAlignment/OAPA/OapaCalibrationGeometry.cs
@@ -15,7 +15,11 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         /// <summary>Discovered calibration factor (motor units per arcminute of axis motion).</summary>
         public float Ratio { get; init; }
 
-        /// <summary>Mechanical backlash measured from the reversal-leg shortfall, in arcminutes.</summary>
+        /// <summary>
+        /// Mechanical backlash measured from the reversal-leg shortfall, in physical axis
+        /// arcminutes (clean − reversal). Physical units make the value valid under the
+        /// discovered <see cref="Ratio"/> when later converted into compensation moves.
+        /// </summary>
         public float BacklashArcmin { get; init; }
 
         /// <summary>True when the forward and reversal legs are antiparallel on the tangent plane.</summary>
@@ -105,13 +109,17 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
             var cleanArcmin = (forwardArcmin + reverseArcmin) / 2.0;
             float observedRatio = (float)(currentRatio * (commandedArcmin / cleanArcmin));
 
-            // The reversal leg lost this much commanded motion to backlash.
-            var backlash = (float)(commandedArcmin * (1.0 - reversalArcmin / cleanArcmin));
+            // The reversal leg physically comes up short by exactly the mechanical backlash.
+            // Measuring the shortfall directly keeps the value in physical axis arcminutes,
+            // valid under the discovered ratio: expressing it via the commanded size would
+            // scale it by the obsolete currentRatio and mis-size every later compensation
+            // move once the new ratio is applied.
+            var backlash = (float)(cleanArcmin - reversalArcmin);
             if (backlash < 0f) {
                 backlash = 0f;
-            } else if (backlash > commandedArcmin / 2f) {
-                warn?.Invoke($"Measured backlash {backlash:F2}' exceeds half the calibration step; clamping. Check for mechanical slippage.");
-                backlash = commandedArcmin / 2f;
+            } else if (backlash > cleanArcmin / 2.0) {
+                warn?.Invoke($"Measured backlash {backlash:F2}' exceeds half the physical calibration leg; clamping. Check for mechanical slippage.");
+                backlash = (float)(cleanArcmin / 2.0);
             }
 
             // The two clean legs measure the same physical motion; a large mismatch means the

--- a/PolarAlignment/OAPA/OapaCalibrationGeometry.cs
+++ b/PolarAlignment/OAPA/OapaCalibrationGeometry.cs
@@ -1,0 +1,133 @@
+using System;
+
+namespace NINA.Plugins.PolarAlignment.OAPA {
+
+    /// <summary>
+    /// A single plate-solved sample used by the OAPA self-calibration: the solved
+    /// field center plus its topocentric altitude at solve time.
+    /// </summary>
+    public readonly record struct CalibrationSolveSample(double RADegrees, double DecDegrees, double AltitudeDegrees);
+
+    /// <summary>
+    /// Result of calibrating a single axis from the four-solve leg sequence.
+    /// </summary>
+    public sealed class AxisCalibrationResult {
+        /// <summary>Discovered calibration factor (motor units per arcminute of axis motion).</summary>
+        public float Ratio { get; init; }
+
+        /// <summary>Mechanical backlash measured from the reversal-leg shortfall, in arcminutes.</summary>
+        public float BacklashArcmin { get; init; }
+
+        /// <summary>True when the forward and reversal legs are antiparallel on the tangent plane.</summary>
+        public bool Consistent { get; init; }
+
+        /// <summary>True when the two backlash-free legs disagree by more than the asymmetry threshold.</summary>
+        public bool Asymmetric { get; init; }
+    }
+
+    /// <summary>
+    /// Pure geometry for the OAPA self-calibration. No hardware, imaging, or UI dependencies,
+    /// so every rule (cos-altitude correction, backlash extraction, consistency and asymmetry
+    /// checks) is unit-testable in isolation.
+    /// </summary>
+    public static class OapaCalibrationGeometry {
+
+        /// <summary>Azimuth calibration degenerates as cos(alt) approaches zero; below this the lever is too foreshortened.</summary>
+        public const double MinimumAzimuthCosAltitude = 0.25;
+
+        /// <summary>Relative disagreement between the two clean legs above which the measurement is flagged unreliable.</summary>
+        public const double AsymmetryThreshold = 0.20;
+
+        /// <summary>Great-circle separation between two solved field centers, in degrees.</summary>
+        public static double AngularSeparationDegrees(CalibrationSolveSample a, CalibrationSolveSample b) {
+            double ra1 = a.RADegrees * Math.PI / 180.0;
+            double ra2 = b.RADegrees * Math.PI / 180.0;
+            double dec1 = a.DecDegrees * Math.PI / 180.0;
+            double dec2 = b.DecDegrees * Math.PI / 180.0;
+            double cosSep = Math.Sin(dec1) * Math.Sin(dec2) + Math.Cos(dec1) * Math.Cos(dec2) * Math.Cos(ra1 - ra2);
+            cosSep = Math.Max(-1.0, Math.Min(1.0, cosSep));
+            return Math.Acos(cosSep) * 180.0 / Math.PI;
+        }
+
+        /// <summary>
+        /// Converts a measured sky displacement between two samples into axis displacement, in
+        /// arcminutes. For the azimuth axis the sky motion is foreshortened by cos(altitude) of
+        /// the observed field — a base rotation of θ moves a field at altitude h by only
+        /// θ·cos(h) — so the measurement is divided by cos(mean altitude). The altitude axis
+        /// transfers 1:1.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The field is too close to the zenith for azimuth calibration.</exception>
+        public static double AxisDisplacementArcmin(bool isAzimuthAxis, CalibrationSolveSample from, CalibrationSolveSample to) {
+            var skyArcmin = AngularSeparationDegrees(from, to) * 60.0;
+            if (!isAzimuthAxis) { return skyArcmin; }
+
+            var meanAlt = (from.AltitudeDegrees + to.AltitudeDegrees) / 2.0;
+            var cosAlt = Math.Cos(meanAlt * Math.PI / 180.0);
+            if (cosAlt < MinimumAzimuthCosAltitude) {
+                throw new InvalidOperationException(
+                    $"Field altitude {meanAlt:F0}\u00b0 is too close to the zenith for azimuth calibration. " +
+                    "Point the scope at a lower altitude (ideally toward the celestial pole) and retry.");
+            }
+            return skyArcmin / cosAlt;
+        }
+
+        /// <summary>
+        /// Dot product of the displacement vectors a1→a2 and b1→b2 projected on the tangent
+        /// plane (RA·cos(dec), Dec) around a1. Negative means antiparallel displacements.
+        /// </summary>
+        public static double TangentDotProduct(CalibrationSolveSample a1, CalibrationSolveSample a2, CalibrationSolveSample b1, CalibrationSolveSample b2) {
+            double cosDec = Math.Cos(a1.DecDegrees * Math.PI / 180.0);
+            double vxA = (a2.RADegrees - a1.RADegrees) * cosDec;
+            double vyA = a2.DecDegrees - a1.DecDegrees;
+            double vxB = (b2.RADegrees - b1.RADegrees) * cosDec;
+            double vyB = b2.DecDegrees - b1.DecDegrees;
+            return vxA * vxB + vyA * vyB;
+        }
+
+        /// <summary>
+        /// Derives the axis calibration from the measured displacements of the four-solve
+        /// sequence: forward (A→B) and reverse (C→D) are single-direction and backlash-free,
+        /// yielding the ratio; the reversal leg (B→C) comes up short by exactly the backlash.
+        /// </summary>
+        /// <param name="commandedArcmin">Commanded size of each leg, in axis arcminutes.</param>
+        /// <param name="currentRatio">Calibration factor the commanded moves were issued with.</param>
+        /// <exception cref="InvalidOperationException">The axis did not move measurably.</exception>
+        public static AxisCalibrationResult ComputeAxisCalibration(
+            float commandedArcmin, float currentRatio,
+            double forwardArcmin, double reversalArcmin, double reverseArcmin,
+            bool tangentDotNegative,
+            Action<string> warn = null) {
+
+            if (forwardArcmin < 0.1 || reverseArcmin < 0.1) {
+                throw new InvalidOperationException("Axis did not move measurably; check clutch and motor current");
+            }
+
+            var cleanArcmin = (forwardArcmin + reverseArcmin) / 2.0;
+            float observedRatio = (float)(currentRatio * (commandedArcmin / cleanArcmin));
+
+            // The reversal leg lost this much commanded motion to backlash.
+            var backlash = (float)(commandedArcmin * (1.0 - reversalArcmin / cleanArcmin));
+            if (backlash < 0f) {
+                backlash = 0f;
+            } else if (backlash > commandedArcmin / 2f) {
+                warn?.Invoke($"Measured backlash {backlash:F2}' exceeds half the calibration step; clamping. Check for mechanical slippage.");
+                backlash = commandedArcmin / 2f;
+            }
+
+            // The two clean legs measure the same physical motion; a large mismatch means the
+            // measurement itself is unreliable (field drift, flexure, slipping mechanics).
+            var asymmetry = Math.Abs(forwardArcmin - reverseArcmin) / Math.Max(forwardArcmin, reverseArcmin);
+            bool asymmetric = asymmetry > AsymmetryThreshold;
+            if (asymmetric) {
+                warn?.Invoke($"Forward ({forwardArcmin:F2}') and reverse ({reverseArcmin:F2}') legs differ by {asymmetry:P0}; discovered values may be unreliable");
+            }
+
+            return new AxisCalibrationResult {
+                Ratio = observedRatio,
+                BacklashArcmin = backlash,
+                Consistent = tangentDotNegative,
+                Asymmetric = asymmetric
+            };
+        }
+    }
+}

--- a/PolarAlignment/OAPA/OapaCalibrationGeometry.cs
+++ b/PolarAlignment/OAPA/OapaCalibrationGeometry.cs
@@ -85,10 +85,22 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         /// flag is flipped, which is what makes the auto-flip retry reachable.
         /// </summary>
         public static bool SignedDisplacementMatchesCommand(bool isAzimuthAxis, CalibrationSolveSample from, CalibrationSolveSample to, float logicalCommand) {
-            double delta = isAzimuthAxis
-                ? WrapDegrees(to.AzimuthDegrees - from.AzimuthDegrees)
-                : to.AltitudeDegrees - from.AltitudeDegrees;
-            return Math.Sign(delta) == Math.Sign(logicalCommand);
+            return Math.Sign(SignedAxisDisplacementArcmin(isAzimuthAxis, from, to)) == Math.Sign(logicalCommand);
+        }
+
+        /// <summary>
+        /// Signed axis displacement between two samples, in arcminutes: positive when the field
+        /// moved in the positive topocentric direction of the axis. Azimuth deltas are wrapped
+        /// across north and corrected for cos(altitude) foreshortening; the cosine is floored at
+        /// <see cref="MinimumAzimuthCosAltitude"/> so restore paths never divide toward zero.
+        /// </summary>
+        public static double SignedAxisDisplacementArcmin(bool isAzimuthAxis, CalibrationSolveSample from, CalibrationSolveSample to) {
+            if (!isAzimuthAxis) {
+                return (to.AltitudeDegrees - from.AltitudeDegrees) * 60.0;
+            }
+            var meanAlt = (from.AltitudeDegrees + to.AltitudeDegrees) / 2.0;
+            var cosAlt = Math.Max(Math.Cos(meanAlt * Math.PI / 180.0), MinimumAzimuthCosAltitude);
+            return WrapDegrees(to.AzimuthDegrees - from.AzimuthDegrees) * 60.0 / cosAlt;
         }
 
         /// <summary>Maps an angle difference into (−180°, 180°] so azimuth deltas across north keep their sign.</summary>

--- a/PolarAlignment/OAPA/OapaCalibrationGeometry.cs
+++ b/PolarAlignment/OAPA/OapaCalibrationGeometry.cs
@@ -4,9 +4,9 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
 
     /// <summary>
     /// A single plate-solved sample used by the OAPA self-calibration: the solved
-    /// field center plus its topocentric altitude at solve time.
+    /// field center plus its topocentric altitude and azimuth at solve time.
     /// </summary>
-    public readonly record struct CalibrationSolveSample(double RADegrees, double DecDegrees, double AltitudeDegrees);
+    public readonly record struct CalibrationSolveSample(double RADegrees, double DecDegrees, double AltitudeDegrees, double AzimuthDegrees);
 
     /// <summary>
     /// Result of calibrating a single axis from the four-solve leg sequence.
@@ -22,7 +22,7 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         /// </summary>
         public float BacklashArcmin { get; init; }
 
-        /// <summary>True when the forward and reversal legs are antiparallel on the tangent plane.</summary>
+        /// <summary>True when the forward leg moved in the topocentric direction the logical command asked for.</summary>
         public bool Consistent { get; init; }
 
         /// <summary>True when the two backlash-free legs disagree by more than the asymmetry threshold.</summary>
@@ -76,16 +76,25 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         }
 
         /// <summary>
-        /// Dot product of the displacement vectors a1→a2 and b1→b2 projected on the tangent
-        /// plane (RA·cos(dec), Dec) around a1. Negative means antiparallel displacements.
+        /// Whether the observed topocentric displacement between two samples matches the sign
+        /// of the logical command that produced it. A positive logical azimuth command must
+        /// increase the field's topocentric azimuth and a positive logical altitude command
+        /// its topocentric altitude — the convention the correction controller and the manual
+        /// nudge buttons assume. A physically reversed axis produces the opposite topocentric
+        /// direction, so this check fails on the first pass and succeeds after the Reverse
+        /// flag is flipped, which is what makes the auto-flip retry reachable.
         /// </summary>
-        public static double TangentDotProduct(CalibrationSolveSample a1, CalibrationSolveSample a2, CalibrationSolveSample b1, CalibrationSolveSample b2) {
-            double cosDec = Math.Cos(a1.DecDegrees * Math.PI / 180.0);
-            double vxA = (a2.RADegrees - a1.RADegrees) * cosDec;
-            double vyA = a2.DecDegrees - a1.DecDegrees;
-            double vxB = (b2.RADegrees - b1.RADegrees) * cosDec;
-            double vyB = b2.DecDegrees - b1.DecDegrees;
-            return vxA * vxB + vyA * vyB;
+        public static bool SignedDisplacementMatchesCommand(bool isAzimuthAxis, CalibrationSolveSample from, CalibrationSolveSample to, float logicalCommand) {
+            double delta = isAzimuthAxis
+                ? WrapDegrees(to.AzimuthDegrees - from.AzimuthDegrees)
+                : to.AltitudeDegrees - from.AltitudeDegrees;
+            return Math.Sign(delta) == Math.Sign(logicalCommand);
+        }
+
+        /// <summary>Maps an angle difference into (−180°, 180°] so azimuth deltas across north keep their sign.</summary>
+        private static double WrapDegrees(double degrees) {
+            var wrapped = degrees - 360.0 * Math.Round(degrees / 360.0);
+            return wrapped == -180.0 ? 180.0 : wrapped;
         }
 
         /// <summary>
@@ -99,7 +108,7 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         public static AxisCalibrationResult ComputeAxisCalibration(
             float commandedArcmin, float currentRatio,
             double forwardArcmin, double reversalArcmin, double reverseArcmin,
-            bool tangentDotNegative,
+            bool directionConsistent,
             Action<string> warn = null) {
 
             if (forwardArcmin < 0.1 || reverseArcmin < 0.1) {
@@ -133,7 +142,7 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
             return new AxisCalibrationResult {
                 Ratio = observedRatio,
                 BacklashArcmin = backlash,
-                Consistent = tangentDotNegative,
+                Consistent = directionConsistent,
                 Asymmetric = asymmetric
             };
         }

--- a/PolarAlignment/OAPA/OapaCalibrationService.cs
+++ b/PolarAlignment/OAPA/OapaCalibrationService.cs
@@ -32,9 +32,11 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
     /// and results are returned as typed values.
     ///
     /// Sequence per axis: baseline solve (fail-fast before any motion), prime +S (absorbs any
-    /// pending backlash), solve A, +S, solve B, -S, solve C, -S, solve D. Net commanded motion
-    /// is zero, so the axis ends where it started; on mid-sequence failure the accumulated
-    /// commanded motion is driven back before rethrowing.
+    /// pending backlash), solve A, +S, solve B, -S, solve C, -S, solve D. The net commanded
+    /// motion is zero but the reversal leg loses the backlash, so the sequence closes the
+    /// loop against the baseline solve to physically return the axis to its start; on
+    /// mid-sequence failure the restore is measured against the baseline too, falling back
+    /// to the commanded sum only when solving is unavailable.
     /// </summary>
     public sealed class OapaCalibrationService {
         private readonly IOapaCalibrationMotion motion;
@@ -136,17 +138,76 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
 
                 Logger.Info($"OAPA cal {axisLabel}: forward={forwardArcmin:F2}', reversal={reversalArcmin:F2}', reverse={reverseArcmin:F2}', " +
                     $"ratio={result.Ratio:F2}, backlash={result.BacklashArcmin:F2}', consistent={result.Consistent}, asymmetric={result.Asymmetric}");
+
+                await CloseLoopAgainstBaseline(axis, isAzimuth, baseline, solveA, solveB, solveD, step, axisLabel, reportStatus, token).ConfigureAwait(false);
                 return result;
             } catch (Exception) when (movedArcmin != 0f) {
-                // Best-effort: drive the axis back to its starting position before surfacing the error.
-                Logger.Info($"OAPA cal {axisLabel}: failure with {movedArcmin:F1}' of commanded motion outstanding; driving back");
+                await BestEffortRestore(axis, isAzimuth, baseline, movedArcmin, axisLabel).ConfigureAwait(false);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// A zero net command sum does not return the axis to its start: the reversal leg
+        /// loses the backlash, leaving the axis roughly one backlash beyond the baseline.
+        /// This measures the residual against the baseline solve and drives it back using
+        /// the response the sequence itself just measured (signed forward displacement per
+        /// wire arcminute), which works identically for normal and reversed axes. The
+        /// closing move continues in the direction of the final legs, so it is itself
+        /// backlash-free in the nominal case. One correction, one verification solve, no
+        /// loops; the move is capped at one calibration step for pathological responses.
+        /// </summary>
+        private async Task CloseLoopAgainstBaseline(
+            Axis axis, bool isAzimuth,
+            CalibrationSolveSample baseline, CalibrationSolveSample solveA, CalibrationSolveSample solveB, CalibrationSolveSample solveD,
+            float wireStep, string axisLabel, Action<string> reportStatus, CancellationToken token) {
+
+            try {
+                var residual = OapaCalibrationGeometry.SignedAxisDisplacementArcmin(isAzimuth, baseline, solveD);
+                if (Math.Abs(residual) < RestoreToleranceArcmin) { return; }
+
+                var responsePerWire = OapaCalibrationGeometry.SignedAxisDisplacementArcmin(isAzimuth, solveA, solveB) / wireStep;
+                if (Math.Abs(responsePerWire) < 1e-3) { return; }
+
+                var closing = (float)Math.Clamp(-residual / responsePerWire, -calibrationStepArcmin, calibrationStepArcmin);
+                reportStatus?.Invoke($"{axisLabel}: returning to start ({residual:+0.0;-0.0}' off)...");
+                await motion.MoveRelative(axis, closing, token).ConfigureAwait(false);
+
+                var verify = await solver.CaptureAndSolve(token).ConfigureAwait(false);
+                var finalResidual = OapaCalibrationGeometry.SignedAxisDisplacementArcmin(isAzimuth, baseline, verify);
+                Logger.Info($"OAPA cal {axisLabel}: closed loop against baseline; residual {finalResidual:F2}' (was {residual:F2}')");
+            } catch (Exception ex) {
+                // The calibration result is already measured; a failed closing move must not discard it.
+                Logger.Warning($"OAPA cal {axisLabel}: failed to close the loop against the baseline ({ex.Message})");
+            }
+        }
+
+        /// <summary>
+        /// Restore after a mid-sequence failure or cancellation. Driving back the commanded
+        /// sum is blind to backlash, so this first tries to measure the true residual against
+        /// the baseline solve and drive that back (assuming the current calibration is roughly
+        /// right; capped for safety). Only when the solve itself is unavailable - often the
+        /// reason the sequence failed - does it fall back to the commanded-sum restore.
+        /// </summary>
+        private async Task BestEffortRestore(Axis axis, bool isAzimuth, CalibrationSolveSample baseline, float movedArcmin, string axisLabel) {
+            try {
+                var current = await solver.CaptureAndSolve(CancellationToken.None).ConfigureAwait(false);
+                var residual = OapaCalibrationGeometry.SignedAxisDisplacementArcmin(isAzimuth, baseline, current);
+                var cap = 3f * calibrationStepArcmin;
+                var restore = (float)Math.Clamp(-residual, -cap, cap);
+                Logger.Info($"OAPA cal {axisLabel}: failure with {movedArcmin:F1}' commanded outstanding; measured {residual:F1}' from baseline, driving back");
+                await motion.MoveRelative(axis, restore, CancellationToken.None).ConfigureAwait(false);
+            } catch (Exception measureEx) {
+                Logger.Warning($"OAPA cal {axisLabel}: measured restore unavailable ({measureEx.Message}); driving back the commanded sum");
                 try {
                     await motion.MoveRelative(axis, -movedArcmin, CancellationToken.None).ConfigureAwait(false);
                 } catch (Exception restoreEx) {
                     Logger.Error($"OAPA cal {axisLabel}: failed to restore start position", restoreEx);
                 }
-                throw;
             }
         }
+
+        /// <summary>Residuals below this are indistinguishable from solve noise and left alone.</summary>
+        private const float RestoreToleranceArcmin = 0.5f;
     }
 }

--- a/PolarAlignment/OAPA/OapaCalibrationService.cs
+++ b/PolarAlignment/OAPA/OapaCalibrationService.cs
@@ -128,10 +128,10 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
                 var forwardArcmin = OapaCalibrationGeometry.AxisDisplacementArcmin(isAzimuth, solveA, solveB);
                 var reversalArcmin = OapaCalibrationGeometry.AxisDisplacementArcmin(isAzimuth, solveB, solveC);
                 var reverseArcmin = OapaCalibrationGeometry.AxisDisplacementArcmin(isAzimuth, solveC, solveD);
-                var tangentDotNegative = OapaCalibrationGeometry.TangentDotProduct(solveA, solveB, solveB, solveC) < 0;
+                var directionConsistent = OapaCalibrationGeometry.SignedDisplacementMatchesCommand(isAzimuth, solveA, solveB, commanded);
 
                 var result = OapaCalibrationGeometry.ComputeAxisCalibration(
-                    commanded, currentRatio, forwardArcmin, reversalArcmin, reverseArcmin, tangentDotNegative,
+                    commanded, currentRatio, forwardArcmin, reversalArcmin, reverseArcmin, directionConsistent,
                     warning => Logger.Warning($"OAPA cal {axisLabel}: {warning}"));
 
                 Logger.Info($"OAPA cal {axisLabel}: forward={forwardArcmin:F2}', reversal={reversalArcmin:F2}', reverse={reverseArcmin:F2}', " +

--- a/PolarAlignment/OAPA/OapaCalibrationService.cs
+++ b/PolarAlignment/OAPA/OapaCalibrationService.cs
@@ -1,0 +1,152 @@
+using NINA.Core.Utility;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Plugins.PolarAlignment.OAPA {
+
+    /// <summary>Motion boundary for the calibration: relative axis moves in axis arcminutes.</summary>
+    public interface IOapaCalibrationMotion {
+        Task MoveRelative(Axis axis, float arcmin, CancellationToken token);
+    }
+
+    /// <summary>Capture-and-solve boundary for the calibration.</summary>
+    public interface IOapaCalibrationSolver {
+        /// <summary>Captures an image and plate-solves it, retrying internally as configured.</summary>
+        Task<CalibrationSolveSample> CaptureAndSolve(CancellationToken token);
+    }
+
+    /// <summary>Outcome of calibrating one axis, including the auto-reverse retry.</summary>
+    public sealed class AxisCalibrationOutcome {
+        public float Ratio { get; init; }
+        public float BacklashArcmin { get; init; }
+        public bool Consistent { get; init; }
+        public bool Asymmetric { get; init; }
+        /// <summary>True when the Reverse flag had to be flipped (and the flip verified) to obtain a consistent result.</summary>
+        public bool Flipped { get; init; }
+    }
+
+    /// <summary>
+    /// Orchestrates the OAPA self-calibration sequence against injected motion and
+    /// capture/solve boundaries. Owns no UI state: progress is reported through a callback
+    /// and results are returned as typed values.
+    ///
+    /// Sequence per axis: baseline solve (fail-fast before any motion), prime +S (absorbs any
+    /// pending backlash), solve A, +S, solve B, -S, solve C, -S, solve D. Net commanded motion
+    /// is zero, so the axis ends where it started; on mid-sequence failure the accumulated
+    /// commanded motion is driven back before rethrowing.
+    /// </summary>
+    public sealed class OapaCalibrationService {
+        private readonly IOapaCalibrationMotion motion;
+        private readonly IOapaCalibrationSolver solver;
+        private readonly float calibrationStepArcmin;
+
+        public OapaCalibrationService(IOapaCalibrationMotion motion, IOapaCalibrationSolver solver, float calibrationStepArcmin = 45.0f) {
+            this.motion = motion;
+            this.solver = solver;
+            this.calibrationStepArcmin = calibrationStepArcmin;
+        }
+
+        /// <summary>
+        /// Calibrates an axis. If the first pass shows direction inconsistency, retries once
+        /// with the direction flipped; a passing retry reports <see cref="AxisCalibrationOutcome.Flipped"/>
+        /// so the caller can persist the corrected Reverse flag.
+        /// </summary>
+        public async Task<AxisCalibrationOutcome> CalibrateAxisWithAutoReverse(
+            Axis axis, float currentRatio, bool reversed,
+            string axisLabel, Action<string> reportStatus, CancellationToken token) {
+
+            var first = await CalibrateAxis(axis, currentRatio, reversed, axisLabel, reportStatus, token).ConfigureAwait(false);
+            if (first.Consistent) {
+                return ToOutcome(first, flipped: false);
+            }
+
+            Logger.Info($"OAPA cal {axisLabel}: direction inconsistent, retrying with Reverse flipped ({reversed} -> {!reversed})");
+            reportStatus?.Invoke($"{axisLabel}: auto-flipping Reverse and retrying...");
+
+            var second = await CalibrateAxis(axis, currentRatio, !reversed, axisLabel, reportStatus, token).ConfigureAwait(false);
+            if (second.Consistent) {
+                Logger.Info($"OAPA cal {axisLabel}: auto-flip succeeded, ratio={second.Ratio:F2}");
+                return ToOutcome(second, flipped: true);
+            }
+
+            Logger.Warning($"OAPA cal {axisLabel}: auto-flip did not resolve inconsistency; keeping original Reverse={reversed}");
+            return ToOutcome(first, flipped: false);
+        }
+
+        private static AxisCalibrationOutcome ToOutcome(AxisCalibrationResult r, bool flipped) => new() {
+            Ratio = r.Ratio,
+            BacklashArcmin = r.BacklashArcmin,
+            Consistent = r.Consistent,
+            Asymmetric = r.Asymmetric,
+            Flipped = flipped
+        };
+
+        private async Task<AxisCalibrationResult> CalibrateAxis(
+            Axis axis, float currentRatio, bool reversed,
+            string axisLabel, Action<string> reportStatus, CancellationToken token) {
+
+            float commanded = calibrationStepArcmin;
+            float step = reversed ? -commanded : commanded;
+            bool isAzimuth = axis == Axis.XAxis;
+
+            // Fail fast on an unsolvable field before commanding any motion.
+            reportStatus?.Invoke($"{axisLabel}: baseline solve...");
+            var baseline = await solver.CaptureAndSolve(token).ConfigureAwait(false);
+
+            if (isAzimuth && Math.Cos(baseline.AltitudeDegrees * Math.PI / 180.0) < OapaCalibrationGeometry.MinimumAzimuthCosAltitude) {
+                throw new InvalidOperationException(
+                    $"{axisLabel}: field altitude {baseline.AltitudeDegrees:F0}\u00b0 is too close to the zenith for azimuth calibration. " +
+                    "Point the scope at a lower altitude (ideally toward the celestial pole) and retry.");
+            }
+
+            float movedArcmin = 0f;
+            try {
+                reportStatus?.Invoke($"{axisLabel}: priming +{commanded:F0}'...");
+                await motion.MoveRelative(axis, step, token).ConfigureAwait(false);
+                movedArcmin += step;
+                var solveA = await solver.CaptureAndSolve(token).ConfigureAwait(false);
+                token.ThrowIfCancellationRequested();
+
+                reportStatus?.Invoke($"{axisLabel}: forward leg +{commanded:F0}'...");
+                await motion.MoveRelative(axis, step, token).ConfigureAwait(false);
+                movedArcmin += step;
+                var solveB = await solver.CaptureAndSolve(token).ConfigureAwait(false);
+                token.ThrowIfCancellationRequested();
+
+                reportStatus?.Invoke($"{axisLabel}: reversal leg -{commanded:F0}'...");
+                await motion.MoveRelative(axis, -step, token).ConfigureAwait(false);
+                movedArcmin -= step;
+                var solveC = await solver.CaptureAndSolve(token).ConfigureAwait(false);
+                token.ThrowIfCancellationRequested();
+
+                reportStatus?.Invoke($"{axisLabel}: reverse leg -{commanded:F0}'...");
+                await motion.MoveRelative(axis, -step, token).ConfigureAwait(false);
+                movedArcmin -= step;
+                var solveD = await solver.CaptureAndSolve(token).ConfigureAwait(false);
+
+                var forwardArcmin = OapaCalibrationGeometry.AxisDisplacementArcmin(isAzimuth, solveA, solveB);
+                var reversalArcmin = OapaCalibrationGeometry.AxisDisplacementArcmin(isAzimuth, solveB, solveC);
+                var reverseArcmin = OapaCalibrationGeometry.AxisDisplacementArcmin(isAzimuth, solveC, solveD);
+                var tangentDotNegative = OapaCalibrationGeometry.TangentDotProduct(solveA, solveB, solveB, solveC) < 0;
+
+                var result = OapaCalibrationGeometry.ComputeAxisCalibration(
+                    commanded, currentRatio, forwardArcmin, reversalArcmin, reverseArcmin, tangentDotNegative,
+                    warning => Logger.Warning($"OAPA cal {axisLabel}: {warning}"));
+
+                Logger.Info($"OAPA cal {axisLabel}: forward={forwardArcmin:F2}', reversal={reversalArcmin:F2}', reverse={reverseArcmin:F2}', " +
+                    $"ratio={result.Ratio:F2}, backlash={result.BacklashArcmin:F2}', consistent={result.Consistent}, asymmetric={result.Asymmetric}");
+                return result;
+            } catch (Exception) when (movedArcmin != 0f) {
+                // Best-effort: drive the axis back to its starting position before surfacing the error.
+                Logger.Info($"OAPA cal {axisLabel}: failure with {movedArcmin:F1}' of commanded motion outstanding; driving back");
+                try {
+                    await motion.MoveRelative(axis, -movedArcmin, CancellationToken.None).ConfigureAwait(false);
+                } catch (Exception restoreEx) {
+                    Logger.Error($"OAPA cal {axisLabel}: failed to restore start position", restoreEx);
+                }
+                throw;
+            }
+        }
+    }
+}

--- a/PolarAlignment/OAPA/OapaPlateSolveSampler.cs
+++ b/PolarAlignment/OAPA/OapaPlateSolveSampler.cs
@@ -63,7 +63,7 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
             var latitude = Angle.ByDegree(profileService.ActiveProfile.AstrometrySettings.Latitude);
             var longitude = Angle.ByDegree(profileService.ActiveProfile.AstrometrySettings.Longitude);
             var topocentric = solve.Coordinates.Transform(latitude, longitude, solve.Coordinates.DateTime.Now);
-            return new CalibrationSolveSample(solve.Coordinates.RADegrees, solve.Coordinates.Dec, topocentric.Altitude.Degree);
+            return new CalibrationSolveSample(solve.Coordinates.RADegrees, solve.Coordinates.Dec, topocentric.Altitude.Degree, topocentric.Azimuth.Degree);
         }
 
         private async Task<PlateSolveResult> CaptureAndSolveOnce(CancellationToken token) {

--- a/PolarAlignment/OAPA/OapaPlateSolveSampler.cs
+++ b/PolarAlignment/OAPA/OapaPlateSolveSampler.cs
@@ -1,0 +1,100 @@
+using NINA.Astrometry;
+using NINA.Core.Model;
+using NINA.Core.Model.Equipment;
+using NINA.Core.Utility;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Model;
+using NINA.Image.Interfaces;
+using NINA.PlateSolving;
+using NINA.PlateSolving.Interfaces;
+using NINA.Profile.Interfaces;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Plugins.PolarAlignment.OAPA {
+
+    /// <summary>
+    /// Capture-and-solve boundary implementation for the OAPA self-calibration: captures a
+    /// snapshot with the profile's plate-solve settings, solves it, and returns the solved
+    /// field center with its topocentric altitude. Retries internally on solver failures.
+    /// </summary>
+    public sealed class OapaPlateSolveSampler : IOapaCalibrationSolver {
+        private const int PlateSolveRetries = 2;
+        private const double SearchRadiusDeg = 30.0;
+
+        private readonly IProfileService profileService;
+        private readonly IImagingMediator imagingMediator;
+        private readonly ITelescopeMediator telescopeMediator;
+        private readonly IPlateSolverFactory plateSolverFactory;
+
+        public OapaPlateSolveSampler(
+            IProfileService profileService,
+            IImagingMediator imagingMediator,
+            ITelescopeMediator telescopeMediator,
+            IPlateSolverFactory plateSolverFactory) {
+            this.profileService = profileService;
+            this.imagingMediator = imagingMediator;
+            this.telescopeMediator = telescopeMediator;
+            this.plateSolverFactory = plateSolverFactory;
+        }
+
+        public async Task<CalibrationSolveSample> CaptureAndSolve(CancellationToken token) {
+            Exception lastException = null;
+            for (int attempt = 0; attempt <= PlateSolveRetries; attempt++) {
+                token.ThrowIfCancellationRequested();
+                try {
+                    var result = await CaptureAndSolveOnce(token).ConfigureAwait(false);
+                    if (result != null && result.Success) {
+                        return ToSample(result);
+                    }
+                    Logger.Warning($"Plate solve unsuccessful (attempt {attempt + 1}/{PlateSolveRetries + 1})");
+                } catch (OperationCanceledException) { throw; } catch (Exception ex) {
+                    lastException = ex;
+                    Logger.Warning($"Plate solve attempt {attempt + 1} failed: {ex.Message}");
+                }
+            }
+            throw new InvalidOperationException(
+                $"Plate solve failed after {PlateSolveRetries + 1} attempts" +
+                (lastException != null ? $": {lastException.Message}" : string.Empty));
+        }
+
+        private CalibrationSolveSample ToSample(PlateSolveResult solve) {
+            var latitude = Angle.ByDegree(profileService.ActiveProfile.AstrometrySettings.Latitude);
+            var longitude = Angle.ByDegree(profileService.ActiveProfile.AstrometrySettings.Longitude);
+            var topocentric = solve.Coordinates.Transform(latitude, longitude, solve.Coordinates.DateTime.Now);
+            return new CalibrationSolveSample(solve.Coordinates.RADegrees, solve.Coordinates.Dec, topocentric.Altitude.Degree);
+        }
+
+        private async Task<PlateSolveResult> CaptureAndSolveOnce(CancellationToken token) {
+            var pss = profileService.ActiveProfile.PlateSolveSettings;
+            var seq = new CaptureSequence() {
+                Binning = new BinningMode(pss.Binning, pss.Binning),
+                Gain = pss.Gain,
+                ExposureTime = pss.ExposureTime,
+                Offset = -1,
+                FilterType = pss.Filter,
+                ImageType = CaptureSequence.ImageTypes.SNAPSHOT
+            };
+
+            IRenderedImage image = await imagingMediator.CaptureAndPrepareImage(
+                seq, new PrepareImageParameters(true, false), token, null);
+            if (image == null) { return null; }
+
+            var solver = plateSolverFactory.GetPlateSolver(pss);
+            var imageSolver = plateSolverFactory.GetImageSolver(solver, null);
+            var parameter = new PlateSolveParameter() {
+                Binning = pss.Binning,
+                Coordinates = telescopeMediator.GetCurrentPosition(),
+                DownSampleFactor = pss.DownSampleFactor,
+                FocalLength = profileService.ActiveProfile.TelescopeSettings.FocalLength,
+                MaxObjects = pss.MaxObjects,
+                PixelSize = profileService.ActiveProfile.CameraSettings.PixelSize,
+                Regions = pss.Regions,
+                SearchRadius = SearchRadiusDeg,
+                DisableNotifications = true
+            };
+            return await imageSolver.Solve(image.RawImageData, parameter, null, token).ConfigureAwait(false);
+        }
+    }
+}

--- a/PolarAlignment/OAPA/UniversalPolarAlignmentOAPAVM.cs
+++ b/PolarAlignment/OAPA/UniversalPolarAlignmentOAPAVM.cs
@@ -153,6 +153,11 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
             }
         }
 
+        // Route the shared clearing logic to the OAPA-specific altitude compensation.
+        protected override float GetBacklashCompensation(Axis axis) {
+            return axis == Axis.YAxis ? YBacklashCompensation : base.GetBacklashCompensation(axis);
+        }
+
         public int XRunCurrent {
             get => Properties.Settings.Default.OAPAXRunCurrent;
             set {

--- a/PolarAlignment/OAPA/UniversalPolarAlignmentOAPAVM.cs
+++ b/PolarAlignment/OAPA/UniversalPolarAlignmentOAPAVM.cs
@@ -1,10 +1,55 @@
 using NINA.Core.Utility;
 using NINA.Profile.Interfaces;
 using NINA.Plugins.PolarAlignment.OAPA;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using NINA.Core.Utility.Notification;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.PlateSolving.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
 
 namespace NINA.Plugins.PolarAlignment.OAPA {
     public partial class UniversalPolarAlignmentOAPAVM : UniversalPolarAlignmentBaseVM {
-        public UniversalPolarAlignmentOAPAVM(IProfileService profileService) : base(profileService) { }
+        private readonly IOapaCalibrationSolver calibrationSolver;
+
+        public UniversalPolarAlignmentOAPAVM(
+            IProfileService profileService,
+            IImagingMediator imagingMediator,
+            ITelescopeMediator telescopeMediator,
+            IPlateSolverFactory plateSolverFactory) : base(profileService) {
+            calibrationSolver = new OapaPlateSolveSampler(profileService, imagingMediator, telescopeMediator, plateSolverFactory);
+
+            // Connected and IsNotMoving live on the base VM. Their generated
+            // [NotifyCanExecuteChangedFor] attributes can't reference commands declared on
+            // this derived class, so re-evaluate the derived commands manually when either
+            // property changes. Connected is flipped from a background Task in the base VM,
+            // so marshal NotifyCanExecuteChanged onto the UI thread. The stored home is only
+            // meaningful for the current controller session (the position counter restarts at
+            // 0 on power-up), so it is invalidated on every connection change.
+            PropertyChanged += (_, e) => {
+                if (e.PropertyName == nameof(Connected) || e.PropertyName == nameof(IsNotMoving)) {
+                    if (e.PropertyName == nameof(Connected)) {
+                        HasHome = false;
+                    }
+                    var dispatcher = Application.Current?.Dispatcher;
+                    if (dispatcher == null || dispatcher.CheckAccess()) {
+                        NotifyDerivedCommands();
+                    } else {
+                        dispatcher.BeginInvoke(new Action(NotifyDerivedCommands));
+                    }
+                }
+            };
+        }
+
+        private void NotifyDerivedCommands() {
+            CalibrateGearRatiosCommand.NotifyCanExecuteChanged();
+            SetHomeCommand.NotifyCanExecuteChanged();
+            GoHomeCommand.NotifyCanExecuteChanged();
+        }
 
         protected override string SystemName => "OAPA System";
 
@@ -97,6 +142,17 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
             }
         }
 
+        // OAPA-specific: the altitude axis of an OAPA platform also has measurable backlash.
+        // Deliberately not part of the shared VM contract - other systems do not model it.
+        public float YBacklashCompensation {
+            get => Properties.Settings.Default.OAPAYBacklashCompensation;
+            set {
+                Properties.Settings.Default.OAPAYBacklashCompensation = value;
+                CoreUtil.SaveSettings(Properties.Settings.Default);
+                RaisePropertyChanged();
+            }
+        }
+
         public int XRunCurrent {
             get => Properties.Settings.Default.OAPAXRunCurrent;
             set {
@@ -143,6 +199,192 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
                     oapa.SetYHoldPercent(value);
                 }
             }
+        }
+
+        // ----- Home position (session-scoped) -----
+        // The controller's position counter restarts at 0 on power-up, so absolute home
+        // coordinates from a previous session are meaningless and potentially harmful.
+        // Home therefore lives in VM state only and is invalidated on every connection change.
+
+        [ObservableProperty]
+        [NotifyCanExecuteChangedFor(nameof(GoHomeCommand))]
+        private bool hasHome;
+
+        [ObservableProperty]
+        private float homeX;
+
+        [ObservableProperty]
+        private float homeY;
+
+        public bool CanSetHome() => Connected && IsNotMoving;
+        public bool CanGoHome() => Connected && IsNotMoving && HasHome;
+
+        [RelayCommand(CanExecute = nameof(CanSetHome))]
+        public void SetHome() {
+            HomeX = PositionX;
+            HomeY = PositionY;
+            HasHome = true;
+            Logger.Info($"OAPA home position set to X={HomeX:F2}, Y={HomeY:F2} (valid for this connection session)");
+            Notification.ShowInformation($"Home position saved for this session (X={HomeX:F2}, Y={HomeY:F2})");
+        }
+
+        [RelayCommand(CanExecute = nameof(CanGoHome))]
+        public async Task GoHome(CancellationToken token) {
+            try {
+                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = false);
+                Logger.Info($"OAPA moving to home position X={HomeX:F2}, Y={HomeY:F2}");
+                await upa.MoveAbsolute(Axis.XAxis, XSpeed, HomeX, token).ConfigureAwait(false);
+                await upa.MoveAbsolute(Axis.YAxis, YSpeed, HomeY, token).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+            } catch (Exception ex) {
+                Logger.Error(ex);
+                Notification.ShowError($"Failed to move to home position: {ex.Message}");
+            } finally {
+                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = true);
+            }
+        }
+
+        // ----- Self-Calibration -----
+        // Orchestration and geometry live in OapaCalibrationService/OapaCalibrationGeometry;
+        // this VM only exposes commands and observable state.
+
+        [ObservableProperty]
+        [NotifyCanExecuteChangedFor(nameof(CalibrateGearRatiosCommand))]
+        private bool calibrationRunning;
+
+        [ObservableProperty]
+        private string calibrationStatus = string.Empty;
+
+        [ObservableProperty]
+        [NotifyCanExecuteChangedFor(nameof(ApplyCalibrationCommand))]
+        [NotifyCanExecuteChangedFor(nameof(DiscardCalibrationCommand))]
+        private bool hasCalibrationResult;
+
+        [ObservableProperty]
+        private float discoveredXRatio;
+
+        [ObservableProperty]
+        private float discoveredYRatio;
+
+        [ObservableProperty]
+        private float discoveredXBacklash;
+
+        [ObservableProperty]
+        private float discoveredYBacklash;
+
+        [ObservableProperty]
+        private string calibrationConsistencyMessage = string.Empty;
+
+        public bool CanCalibrate() => Connected && IsNotMoving && !CalibrationRunning;
+
+        private sealed class SpeedAwareMotion : IOapaCalibrationMotion {
+            private readonly UniversalPolarAlignmentOAPAVM vm;
+            public SpeedAwareMotion(UniversalPolarAlignmentOAPAVM vm) { this.vm = vm; }
+            public Task MoveRelative(Axis axis, float arcmin, CancellationToken token) {
+                var speed = axis == Axis.XAxis ? vm.XSpeed : vm.YSpeed;
+                return vm.upa.MoveRelative(axis, speed, arcmin, token);
+            }
+        }
+
+        [RelayCommand(CanExecute = nameof(CanCalibrate))]
+        public Task CalibrateGearRatios(CancellationToken token) {
+            return Task.Run(async () => {
+                try {
+                    await Application.Current.Dispatcher.BeginInvoke(() => {
+                        IsNotMoving = false;
+                        CalibrationRunning = true;
+                        HasCalibrationResult = false;
+                        CalibrationStatus = "Starting calibration...";
+                        CalibrationConsistencyMessage = string.Empty;
+                    });
+
+                    Logger.Info("OAPA self-calibration started");
+                    var service = new OapaCalibrationService(new SpeedAwareMotion(this), calibrationSolver);
+                    Action<string> reportStatus = s => Application.Current.Dispatcher.BeginInvoke(() => CalibrationStatus = s);
+
+                    var x = await service.CalibrateAxisWithAutoReverse(
+                        Axis.XAxis, XGearRatio, ReverseAzimuth, "X (Azimuth)", reportStatus, token);
+                    if (x.Flipped) {
+                        await Application.Current.Dispatcher.BeginInvoke(() => ReverseAzimuth = !ReverseAzimuth);
+                    }
+                    var y = await service.CalibrateAxisWithAutoReverse(
+                        Axis.YAxis, YGearRatio, ReverseAltitude, "Y (Altitude)", reportStatus, token);
+                    if (y.Flipped) {
+                        await Application.Current.Dispatcher.BeginInvoke(() => ReverseAltitude = !ReverseAltitude);
+                    }
+
+                    string consistencyMsg;
+                    if (x.Consistent && y.Consistent) {
+                        var notes = new List<string>();
+                        if (x.Flipped) { notes.Add("Reverse Az auto-corrected"); }
+                        if (y.Flipped) { notes.Add("Reverse Alt auto-corrected"); }
+                        consistencyMsg = notes.Count == 0
+                            ? "Direction consistency: OK"
+                            : "Direction consistency: OK (" + string.Join(", ", notes) + ")";
+                    } else {
+                        consistencyMsg = $"Direction consistency: WARNING (X={(x.Consistent ? "ok" : "fail")}, Y={(y.Consistent ? "ok" : "fail")}). Auto-flip did not resolve it; check wiring.";
+                    }
+                    if (x.Asymmetric || y.Asymmetric) {
+                        var axes = x.Asymmetric && y.Asymmetric ? "X and Y" : (x.Asymmetric ? "X" : "Y");
+                        consistencyMsg += $" \u26a0 Forward/reverse legs on {axes} differ by more than 20%: the discovered values may be unreliable. Re-run with the scope pointing at a lower-altitude, star-rich field.";
+                    }
+
+                    await Application.Current.Dispatcher.BeginInvoke(() => {
+                        DiscoveredXRatio = x.Ratio;
+                        DiscoveredYRatio = y.Ratio;
+                        DiscoveredXBacklash = x.BacklashArcmin;
+                        DiscoveredYBacklash = y.BacklashArcmin;
+                        CalibrationConsistencyMessage = consistencyMsg;
+                        CalibrationStatus = $"Done. X={x.Ratio:F2}, Y={y.Ratio:F2}, backlash X={x.BacklashArcmin:F2}', Y={y.BacklashArcmin:F2}'";
+                        HasCalibrationResult = true;
+                    });
+
+                    Logger.Info($"OAPA calibration result: X={x.Ratio:F2}, Y={y.Ratio:F2}, backlash X={x.BacklashArcmin:F2}', Y={y.BacklashArcmin:F2}', consistency: X={x.Consistent}, Y={y.Consistent}");
+                    Notification.ShowInformation(
+                        $"Calibration done. X factor: {x.Ratio:F2}, Y factor: {y.Ratio:F2}, backlash X: {x.BacklashArcmin:F2}', Y: {y.BacklashArcmin:F2}'",
+                        TimeSpan.FromSeconds(30));
+                } catch (OperationCanceledException) {
+                    Logger.Info("OAPA self-calibration cancelled");
+                    await Application.Current.Dispatcher.BeginInvoke(() => CalibrationStatus = "Cancelled");
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                    Notification.ShowError($"Calibration failed: {ex.Message}");
+                    await Application.Current.Dispatcher.BeginInvoke(() => CalibrationStatus = $"Failed: {ex.Message}");
+                } finally {
+                    await Application.Current.Dispatcher.BeginInvoke(() => {
+                        CalibrationRunning = false;
+                        IsNotMoving = true;
+                    });
+                }
+            });
+        }
+
+        [RelayCommand(CanExecute = nameof(HasCalibrationResult))]
+        public void ApplyCalibration() {
+            try {
+                XGearRatio = DiscoveredXRatio;
+                YGearRatio = DiscoveredYRatio;
+                XBacklashCompensation = DiscoveredXBacklash;
+                YBacklashCompensation = DiscoveredYBacklash;
+                HasCalibrationResult = false;
+                CalibrationStatus = "Applied";
+                Logger.Info($"OAPA calibration applied: X={DiscoveredXRatio:F2}, Y={DiscoveredYRatio:F2}, backlash X={DiscoveredXBacklash:F2}', Y={DiscoveredYBacklash:F2}'");
+                Notification.ShowInformation("Calibration factors and backlash compensation updated", TimeSpan.FromSeconds(30));
+            } catch (Exception ex) {
+                Logger.Error(ex);
+                Notification.ShowError($"Failed to apply calibration: {ex.Message}");
+            }
+        }
+
+        [RelayCommand(CanExecute = nameof(HasCalibrationResult))]
+        public void DiscardCalibration() {
+            DiscoveredXRatio = 0;
+            DiscoveredYRatio = 0;
+            DiscoveredXBacklash = 0;
+            DiscoveredYBacklash = 0;
+            HasCalibrationResult = false;
+            CalibrationConsistencyMessage = string.Empty;
+            CalibrationStatus = "Discarded";
         }
     }
 }

--- a/PolarAlignment/OAPA/UniversalPolarAlignmentOAPAVM.cs
+++ b/PolarAlignment/OAPA/UniversalPolarAlignmentOAPAVM.cs
@@ -87,6 +87,7 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
                 CoreUtil.SaveSettings(Properties.Settings.Default);
                 RaisePropertyChanged();
                 RaisePropertyChanged(nameof(PositionX));
+                RefreshHomeDisplay();
             }
         }
 
@@ -108,6 +109,7 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
                 CoreUtil.SaveSettings(Properties.Settings.Default);
                 RaisePropertyChanged();
                 RaisePropertyChanged(nameof(PositionY));
+                RefreshHomeDisplay();
             }
         }
 
@@ -215,6 +217,16 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         // The controller's position counter restarts at 0 on power-up, so absolute home
         // coordinates from a previous session are meaningless and potentially harmful.
         // Home therefore lives in VM state only and is invalidated on every connection change.
+        //
+        // Home marks a physical controller position, so it is stored in controller-native
+        // units: the displayed logical position is the controller position divided by the
+        // gear ratio, and MoveAbsolute multiplies by it again, so a logical value saved
+        // under one ratio drives somewhere else once the ratio changes (manual edit or
+        // ApplyCalibration). HomeX/HomeY are display-only projections under the current
+        // ratio, refreshed by the ratio setters.
+
+        private float homeXController;
+        private float homeYController;
 
         [ObservableProperty]
         [NotifyCanExecuteChangedFor(nameof(GoHomeCommand))]
@@ -229,12 +241,20 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         public bool CanSetHome() => Connected && IsNotMoving;
         public bool CanGoHome() => Connected && IsNotMoving && HasHome;
 
+        private void RefreshHomeDisplay() {
+            if (!HasHome) { return; }
+            HomeX = homeXController / XGearRatio;
+            HomeY = homeYController / YGearRatio;
+        }
+
         [RelayCommand(CanExecute = nameof(CanSetHome))]
         public void SetHome() {
+            homeXController = PositionX * XGearRatio;
+            homeYController = PositionY * YGearRatio;
             HomeX = PositionX;
             HomeY = PositionY;
             HasHome = true;
-            Logger.Info($"OAPA home position set to X={HomeX:F2}, Y={HomeY:F2} (valid for this connection session)");
+            Logger.Info($"OAPA home position set to X={HomeX:F2}, Y={HomeY:F2} (controller {homeXController:F0}/{homeYController:F0}, valid for this connection session)");
             Notification.ShowInformation($"Home position saved for this session (X={HomeX:F2}, Y={HomeY:F2})");
         }
 
@@ -242,9 +262,11 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         public async Task GoHome(CancellationToken token) {
             try {
                 await RunOnUi(() => IsNotMoving = false);
-                Logger.Info($"OAPA moving to home position X={HomeX:F2}, Y={HomeY:F2}");
-                await upa.MoveAbsolute(Axis.XAxis, XSpeed, HomeX, token).ConfigureAwait(false);
-                await upa.MoveAbsolute(Axis.YAxis, YSpeed, HomeY, token).ConfigureAwait(false);
+                var targetX = homeXController / XGearRatio;
+                var targetY = homeYController / YGearRatio;
+                Logger.Info($"OAPA moving to home position X={targetX:F2}, Y={targetY:F2} (controller {homeXController:F0}/{homeYController:F0})");
+                await upa.MoveAbsolute(Axis.XAxis, XSpeed, targetX, token).ConfigureAwait(false);
+                await upa.MoveAbsolute(Axis.YAxis, YSpeed, targetY, token).ConfigureAwait(false);
             } catch (OperationCanceledException) {
             } catch (Exception ex) {
                 Logger.Error(ex);

--- a/PolarAlignment/OAPA/UniversalPolarAlignmentOAPAVM.cs
+++ b/PolarAlignment/OAPA/UniversalPolarAlignmentOAPAVM.cs
@@ -4,6 +4,7 @@ using NINA.Plugins.PolarAlignment.OAPA;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using NINA.Core.Utility.Notification;
+using NINA.Equipment.Equipment.MyCamera;
 using NINA.Equipment.Interfaces.Mediator;
 using NINA.PlateSolving.Interfaces;
 using System;
@@ -15,13 +16,17 @@ using System.Windows;
 namespace NINA.Plugins.PolarAlignment.OAPA {
     public partial class UniversalPolarAlignmentOAPAVM : UniversalPolarAlignmentBaseVM {
         private readonly IOapaCalibrationSolver calibrationSolver;
+        private readonly ICameraMediator cameraMediator;
+        private readonly CameraBlockToken cameraBlockToken = new();
 
         public UniversalPolarAlignmentOAPAVM(
             IProfileService profileService,
             IImagingMediator imagingMediator,
             ITelescopeMediator telescopeMediator,
-            IPlateSolverFactory plateSolverFactory) : base(profileService) {
+            IPlateSolverFactory plateSolverFactory,
+            ICameraMediator cameraMediator) : base(profileService) {
             calibrationSolver = new OapaPlateSolveSampler(profileService, imagingMediator, telescopeMediator, plateSolverFactory);
+            this.cameraMediator = cameraMediator;
 
             // Connected and IsNotMoving live on the base VM. Their generated
             // [NotifyCanExecuteChangedFor] attributes can't reference commands declared on
@@ -236,7 +241,7 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         [RelayCommand(CanExecute = nameof(CanGoHome))]
         public async Task GoHome(CancellationToken token) {
             try {
-                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = false);
+                await RunOnUi(() => IsNotMoving = false);
                 Logger.Info($"OAPA moving to home position X={HomeX:F2}, Y={HomeY:F2}");
                 await upa.MoveAbsolute(Axis.XAxis, XSpeed, HomeX, token).ConfigureAwait(false);
                 await upa.MoveAbsolute(Axis.YAxis, YSpeed, HomeY, token).ConfigureAwait(false);
@@ -245,7 +250,7 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
                 Logger.Error(ex);
                 Notification.ShowError($"Failed to move to home position: {ex.Message}");
             } finally {
-                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = true);
+                await RunOnUi(() => IsNotMoving = true);
             }
         }
 
@@ -280,7 +285,17 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         [ObservableProperty]
         private string calibrationConsistencyMessage = string.Empty;
 
-        public bool CanCalibrate() => Connected && IsNotMoving && !CalibrationRunning;
+        public bool CanCalibrate() => Connected && IsNotMoving && !CalibrationRunning && CameraIsFree();
+
+        // The capture block owner is identified by reference; a dedicated token keeps the
+        // camera-consumer plumbing off the public VM surface. A null mediator (tests,
+        // headless hosts) means "always free" with no-op acquisition.
+        private bool CameraIsFree() => cameraMediator == null || cameraMediator.IsFreeToCapture(cameraBlockToken);
+
+        private sealed class CameraBlockToken : ICameraConsumer {
+            public void UpdateDeviceInfo(CameraInfo deviceInfo) { }
+            public void Dispose() { }
+        }
 
         private sealed class SpeedAwareMotion : IOapaCalibrationMotion {
             private readonly UniversalPolarAlignmentOAPAVM vm;
@@ -294,8 +309,17 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
         [RelayCommand(CanExecute = nameof(CanCalibrate))]
         public Task CalibrateGearRatios(CancellationToken token) {
             return Task.Run(async () => {
+                // CanExecute is evaluated at UI time; re-check here so a sequence or another
+                // TPPA run that acquired the camera in the meantime cannot be interrupted.
+                if (!CameraIsFree()) {
+                    Logger.Warning("OAPA self-calibration refused: another consumer owns the camera");
+                    Notification.ShowWarning("Cannot calibrate: the camera is in use by a sequence or another imaging process.");
+                    await RunOnUi(() => CalibrationStatus = "Camera busy - calibration not started");
+                    return;
+                }
+                cameraMediator?.RegisterCaptureBlock(cameraBlockToken);
                 try {
-                    await Application.Current.Dispatcher.BeginInvoke(() => {
+                    await RunOnUi(() => {
                         IsNotMoving = false;
                         CalibrationRunning = true;
                         HasCalibrationResult = false;
@@ -305,17 +329,17 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
 
                     Logger.Info("OAPA self-calibration started");
                     var service = new OapaCalibrationService(new SpeedAwareMotion(this), calibrationSolver);
-                    Action<string> reportStatus = s => Application.Current.Dispatcher.BeginInvoke(() => CalibrationStatus = s);
+                    Action<string> reportStatus = s => _ = RunOnUi(() => CalibrationStatus = s);
 
                     var x = await service.CalibrateAxisWithAutoReverse(
                         Axis.XAxis, XGearRatio, ReverseAzimuth, "X (Azimuth)", reportStatus, token);
                     if (x.Flipped) {
-                        await Application.Current.Dispatcher.BeginInvoke(() => ReverseAzimuth = !ReverseAzimuth);
+                        await RunOnUi(() => ReverseAzimuth = !ReverseAzimuth);
                     }
                     var y = await service.CalibrateAxisWithAutoReverse(
                         Axis.YAxis, YGearRatio, ReverseAltitude, "Y (Altitude)", reportStatus, token);
                     if (y.Flipped) {
-                        await Application.Current.Dispatcher.BeginInvoke(() => ReverseAltitude = !ReverseAltitude);
+                        await RunOnUi(() => ReverseAltitude = !ReverseAltitude);
                     }
 
                     string consistencyMsg;
@@ -334,7 +358,7 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
                         consistencyMsg += $" \u26a0 Forward/reverse legs on {axes} differ by more than 20%: the discovered values may be unreliable. Re-run with the scope pointing at a lower-altitude, star-rich field.";
                     }
 
-                    await Application.Current.Dispatcher.BeginInvoke(() => {
+                    await RunOnUi(() => {
                         DiscoveredXRatio = x.Ratio;
                         DiscoveredYRatio = y.Ratio;
                         DiscoveredXBacklash = x.BacklashArcmin;
@@ -350,13 +374,14 @@ namespace NINA.Plugins.PolarAlignment.OAPA {
                         TimeSpan.FromSeconds(30));
                 } catch (OperationCanceledException) {
                     Logger.Info("OAPA self-calibration cancelled");
-                    await Application.Current.Dispatcher.BeginInvoke(() => CalibrationStatus = "Cancelled");
+                    await RunOnUi(() => CalibrationStatus = "Cancelled");
                 } catch (Exception ex) {
                     Logger.Error(ex);
                     Notification.ShowError($"Calibration failed: {ex.Message}");
-                    await Application.Current.Dispatcher.BeginInvoke(() => CalibrationStatus = $"Failed: {ex.Message}");
+                    await RunOnUi(() => CalibrationStatus = $"Failed: {ex.Message}");
                 } finally {
-                    await Application.Current.Dispatcher.BeginInvoke(() => {
+                    cameraMediator?.ReleaseCaptureBlock(cameraBlockToken);
+                    await RunOnUi(() => {
                         CalibrationRunning = false;
                         IsNotMoving = true;
                     });

--- a/PolarAlignment/PolarAlignmentPlugin.cs
+++ b/PolarAlignment/PolarAlignmentPlugin.cs
@@ -17,6 +17,8 @@ using NINA.Plugins.PolarAlignment.Avalon;
 using NINA.Plugins.PolarAlignment.OAPA;
 using NINA.Profile;
 using NINA.Profile.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.PlateSolving.Interfaces;
 
 namespace NINA.Plugins.PolarAlignment {
     [Export(typeof(IPluginManifest))]
@@ -57,7 +59,11 @@ namespace NINA.Plugins.PolarAlignment {
         public static string PluginId { get; private set; }
 
         [ImportingConstructor]
-        public PolarAlignmentPlugin(IProfileService profileService) {
+        public PolarAlignmentPlugin(
+            IProfileService profileService,
+            IImagingMediator imagingMediator,
+            ITelescopeMediator telescopeMediator,
+            IPlateSolverFactory plateSolverFactory) {
             if (Properties.Settings.Default.UpdateSettings) {
                 Properties.Settings.Default.Upgrade();
                 Properties.Settings.Default.UpdateSettings = false;
@@ -65,7 +71,8 @@ namespace NINA.Plugins.PolarAlignment {
             }
             ResetSettingsCommand = new GalaSoft.MvvmLight.Command.RelayCommand(ResetSettings);
             UniversalPolarAlignmentVM = new UniversalPolarAlignmentVM(profileService);
-            UniversalPolarAlignmentOAPAVM = new UniversalPolarAlignmentOAPAVM(profileService);
+            UniversalPolarAlignmentOAPAVM = new UniversalPolarAlignmentOAPAVM(
+                profileService, imagingMediator, telescopeMediator, plateSolverFactory);
             PluginId = this.Identifier;
         }
 

--- a/PolarAlignment/PolarAlignmentPlugin.cs
+++ b/PolarAlignment/PolarAlignmentPlugin.cs
@@ -63,7 +63,8 @@ namespace NINA.Plugins.PolarAlignment {
             IProfileService profileService,
             IImagingMediator imagingMediator,
             ITelescopeMediator telescopeMediator,
-            IPlateSolverFactory plateSolverFactory) {
+            IPlateSolverFactory plateSolverFactory,
+            ICameraMediator cameraMediator) {
             if (Properties.Settings.Default.UpdateSettings) {
                 Properties.Settings.Default.Upgrade();
                 Properties.Settings.Default.UpdateSettings = false;
@@ -72,7 +73,7 @@ namespace NINA.Plugins.PolarAlignment {
             ResetSettingsCommand = new GalaSoft.MvvmLight.Command.RelayCommand(ResetSettings);
             UniversalPolarAlignmentVM = new UniversalPolarAlignmentVM(profileService);
             UniversalPolarAlignmentOAPAVM = new UniversalPolarAlignmentOAPAVM(
-                profileService, imagingMediator, telescopeMediator, plateSolverFactory);
+                profileService, imagingMediator, telescopeMediator, plateSolverFactory, cameraMediator);
             PluginId = this.Identifier;
         }
 

--- a/PolarAlignment/Properties/Settings.Designer.cs
+++ b/PolarAlignment/Properties/Settings.Designer.cs
@@ -457,6 +457,18 @@ namespace NINA.Plugins.PolarAlignment.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public float OAPAYBacklashCompensation {
+            get {
+                return ((float)(this["OAPAYBacklashCompensation"]));
+            }
+            set {
+                this["OAPAYBacklashCompensation"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool OAPAReverseAzimuth {
             get {

--- a/PolarAlignment/Properties/Settings.settings
+++ b/PolarAlignment/Properties/Settings.settings
@@ -110,6 +110,9 @@
     <Setting Name="OAPAXBacklashCompensation" Type="System.Single" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="OAPAYBacklashCompensation" Type="System.Single" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
     <Setting Name="OAPAReverseAzimuth" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>

--- a/PolarAlignment/UniversalPolarAlignmentBaseVM.cs
+++ b/PolarAlignment/UniversalPolarAlignmentBaseVM.cs
@@ -11,13 +11,26 @@ using System.Windows;
 
 namespace NINA.Plugins.PolarAlignment {
     public abstract partial class UniversalPolarAlignmentBaseVM : BaseVM, IPolarAlignmentSystemVM {
-        protected IPolarAlignmentSystem upa;
+        protected internal IPolarAlignmentSystem upa;
 
         protected abstract IPolarAlignmentSystem CreateSystem();
         protected abstract string SystemName { get; }
 
         protected UniversalPolarAlignmentBaseVM(IProfileService profileService) : base(profileService) {
             IsNotMoving = true;
+        }
+
+        /// <summary>
+        /// Marshals UI-affecting property changes to the dispatcher when a WPF application
+        /// exists; test hosts without one invoke directly.
+        /// </summary>
+        protected static async Task RunOnUi(Action action) {
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher != null) {
+                await dispatcher.BeginInvoke(action);
+            } else {
+                action();
+            }
         }
 
         [ObservableProperty]
@@ -59,7 +72,7 @@ namespace NINA.Plugins.PolarAlignment {
             if (upa?.Connected == true) { return Task.CompletedTask; }
             return Task.Run(async () => {
                 try {
-                    await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = true);
+                    await RunOnUi(() => IsNotMoving = true);
 
                     upa = CreateSystem();
                     _ = StartPoll();
@@ -93,13 +106,13 @@ namespace NINA.Plugins.PolarAlignment {
         public async Task<bool> TryNudgeX(float position, CancellationToken token) {
             try {
                 if (ReverseAzimuth) { position = position * -1; }
-                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = false);
+                await RunOnUi(() => IsNotMoving = false);
 
                 Logger.Info($"Nudging {SystemName} along X axis by {position}");
                 var lastDirection = upa.XLastDirection;
                 await upa.MoveRelative(Axis.XAxis, XSpeed, position, token).ConfigureAwait(false);
                 var currentDirection = upa.XLastDirection;
-                await ClearBacklash(lastDirection, currentDirection, token);
+                await ClearBacklash(Axis.XAxis, XSpeed, lastDirection, currentDirection, token);
                 return true;
             } catch (Exception ex) {
                 Logger.Error(ex);
@@ -108,7 +121,7 @@ namespace NINA.Plugins.PolarAlignment {
                 }
                 return false;
             } finally {
-                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = true);
+                await RunOnUi(() => IsNotMoving = true);
             }
         }
 
@@ -120,10 +133,13 @@ namespace NINA.Plugins.PolarAlignment {
         public async Task<bool> TryNudgeY(float position, CancellationToken token) {
             try {
                 if (ReverseAltitude) { position = position * -1; }
-                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = false);
+                await RunOnUi(() => IsNotMoving = false);
 
                 Logger.Info($"Nudging {SystemName} along Y axis by {position}");
+                var lastDirection = upa.YLastDirection;
                 await upa.MoveRelative(Axis.YAxis, YSpeed, position, token).ConfigureAwait(false);
+                var currentDirection = upa.YLastDirection;
+                await ClearBacklash(Axis.YAxis, YSpeed, lastDirection, currentDirection, token);
                 return true;
             } catch (Exception ex) {
                 Logger.Error(ex);
@@ -132,7 +148,7 @@ namespace NINA.Plugins.PolarAlignment {
                 }
                 return false;
             } finally {
-                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = true);
+                await RunOnUi(() => IsNotMoving = true);
             }
         }
 
@@ -143,7 +159,7 @@ namespace NINA.Plugins.PolarAlignment {
         [RelayCommand(CanExecute = (nameof(IsNotMoving)))]
         public async Task MoveX(CancellationToken token) {
             try {
-                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = false);
+                await RunOnUi(() => IsNotMoving = false);
 
                 var target = TargetPositionX;
                 if (ReverseAzimuth) { target = target * -1; }
@@ -153,24 +169,34 @@ namespace NINA.Plugins.PolarAlignment {
 
                 await upa.MoveAbsolute(Axis.XAxis, XSpeed, target, token).ConfigureAwait(false);
                 var currentDirection = upa.XLastDirection;
-                await ClearBacklash(lastDirection, currentDirection, token);
+                await ClearBacklash(Axis.XAxis, XSpeed, lastDirection, currentDirection, token);
             } catch (Exception ex) {
                 Logger.Error(ex);
                 if (ex is TimeoutException) {
                     Notification.ShowError($"Movement timeout: {ex.Message}");
                 }
             } finally {
-                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = true);
+                await RunOnUi(() => IsNotMoving = true);
             }
         }
 
-        private async Task ClearBacklash(LastDirection lastDirection, LastDirection currentDirection, CancellationToken token) {
+        /// <summary>
+        /// Backlash compensation for the given axis. The base policy compensates azimuth
+        /// only: the Avalon UPAS altitude axis does not use backlash compensation. Systems
+        /// with a measured altitude backlash (OAPA) override this to supply it.
+        /// </summary>
+        protected virtual float GetBacklashCompensation(Axis axis) {
+            return axis == Axis.XAxis ? XBacklashCompensation : 0f;
+        }
+
+        private async Task ClearBacklash(Axis axis, int speed, LastDirection lastDirection, LastDirection currentDirection, CancellationToken token) {
             if (lastDirection != currentDirection) {
-                if (Math.Abs(XBacklashCompensation) > 0) {
-                    Logger.Info("Direction changed. Clearing backlash");
-                    var sequence = BacklashCompensationPlanner.CreateSequence(XBacklashCompensation, currentDirection);
-                    await upa.MoveRelative(Axis.XAxis, XSpeed, sequence.FirstMove, token).ConfigureAwait(false);
-                    await upa.MoveRelative(Axis.XAxis, XSpeed, sequence.SecondMove, token).ConfigureAwait(false);
+                var compensation = GetBacklashCompensation(axis);
+                if (Math.Abs(compensation) > 0) {
+                    Logger.Info($"Direction changed on {axis}. Clearing backlash");
+                    var sequence = BacklashCompensationPlanner.CreateSequence(compensation, currentDirection);
+                    await upa.MoveRelative(axis, speed, sequence.FirstMove, token).ConfigureAwait(false);
+                    await upa.MoveRelative(axis, speed, sequence.SecondMove, token).ConfigureAwait(false);
                 }
             }
         }
@@ -178,20 +204,23 @@ namespace NINA.Plugins.PolarAlignment {
         [RelayCommand(CanExecute = (nameof(IsNotMoving)))]
         public async Task MoveY(CancellationToken token) {
             try {
-                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = false);
+                await RunOnUi(() => IsNotMoving = false);
 
                 var target = TargetPositionY;
                 if (ReverseAltitude) { target = target * -1; }
 
                 Logger.Info($"Moving {SystemName} along Y axis to {target}");
+                var lastDirection = upa.YLastDirection;
                 await upa.MoveAbsolute(Axis.YAxis, YSpeed, target, token).ConfigureAwait(false);
+                var currentDirection = upa.YLastDirection;
+                await ClearBacklash(Axis.YAxis, YSpeed, lastDirection, currentDirection, token);
             } catch (Exception ex) {
                 Logger.Error(ex);
                 if (ex is TimeoutException) {
                     Notification.ShowError($"Movement timeout: {ex.Message}");
                 }
             } finally {
-                await Application.Current.Dispatcher.BeginInvoke(() => IsNotMoving = true);
+                await RunOnUi(() => IsNotMoving = true);
             }
         }
 


### PR DESCRIPTION
Third of the split series from #13 (3 of 4) — the OAPA-scoped bulk, restructured per the review.

## What

Adds **Self-Calibration** and **Home Position** support to the OAPA control dock. The calibration discovers each axis's real calibration factor and mechanical backlash directly on the sky, so users no longer need to compute gear reductions or guess backlash values (which previously defaulted to 0 — a major cause of oscillation during automated correction).

Per axis: baseline solve → priming leg (+45', absorbs pending backlash) → solve → forward leg → solve → reversal leg → solve → reverse leg → solve. The two single-direction legs are backlash-free and yield the factor; the reversal leg comes up short by exactly the backlash. Net commanded motion is zero.

Key correctness rules, all field-discovered:
- **cos(field altitude) correction on azimuth** — a base rotation of θ moves a field at altitude h by θ·cos(h). Without it, calibration was field-dependent (same hardware: factor 52.34 calibrating at alt ~79° vs 16.46 near the pole → runaway corrections). With it, two independent calibrations agreed within ~4% (14.91 vs 14.31; backlash 5.05' vs 5.12').
- Zenith guard (cos(alt) < 0.25 refuses the azimuth leg), fail-fast baseline solve before any motion, best-effort position restore on mid-sequence failure, >20% leg-asymmetry warning, automatic Reverse-flag correction with one verified retry.

## Structure (addressing the #13 review)

- **`OapaCalibrationGeometry`** — pure static geometry returning typed results; no hardware, imaging, or UI dependencies.
- **`OapaCalibrationService`** — sequence orchestration against two injected boundaries (`IOapaCalibrationMotion`, `IOapaCalibrationSolver`); progress via callback, results as typed values.
- **`OapaPlateSolveSampler`** — the capture/solve boundary implementation (profile plate-solve settings, internal retry).
- **VM** exposes only commands and observable state.
- **Home is session-scoped**: stored in VM state, invalidated on every connection change — stale coordinates from a previous power session can never be driven to.
- **Altitude-axis backlash stays on the OAPA VM** (plain property + OAPA-only setting); nothing is added to the shared VM contract, Avalon untouched.
- Everything lives under `PolarAlignment/OAPA` except: plugin constructor gains three MEF imports to construct the sampler, and one new OAPA-prefixed user setting.

## Testing

- **15 new unit tests**: geometry rules (cos(alt) correction, zenith guard, backlash extraction, ratio scaling, asymmetry flag, clamping) and the full service sequence against a simulated axis with configurable response and backlash (response recovery, backlash recovery within 0.5', zero net commanded motion, restore-on-failure, zenith abort before motion).
- Full suite green (62/62).
- Field validation (beta testers, real OAPA hardware): calibration reproducible within ~4% across independent runs; with the discovered values, hands-off runs from 1°14' to 0.36' in ~6 min / 19 solves and from 8' to 0.45' in ~3 min.

Changelog assumes merge after #14/#15; happy to rebase/renumber. Last piece of the series (shared controller changes) follows separately.
